### PR TITLE
Enhanced the style of heatmap header navigation arrows 

### DIFF
--- a/src/styles/heatmap-tracker-header.scss
+++ b/src/styles/heatmap-tracker-header.scss
@@ -26,6 +26,8 @@
 
 .heatmap-tracker-header__navigation {
   display: flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
   align-items: center;
 }
 


### PR DESCRIPTION
Arrows in heatmap-header-navigation responsible for year change were placed wrongly. I corrected the position by adding flex style in related scss file.