### PR TITLE
feat: add monthly layout mode with date range support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+### Added
+- Monthly layout mode (`layout: "monthly"`) — renders one row per month with days 1–31 as columns.
+- Date range parameters: `monthsToShow`, `daysToShow`, `startDate`, `endDate` for partial year views.
+- Year navigation is automatically hidden when a date range is active.
+
 ## [2.1.7] - 2026-03-10
 ### Added
 - Comprehensive RTL (Right-to-Left) support for improved usability in languages like Hebrew and Arabic.

--- a/EXAMPLE_VAULT/Documentation with Examples/3. trackerData parameters/12. layout.md
+++ b/EXAMPLE_VAULT/Documentation with Examples/3. trackerData parameters/12. layout.md
@@ -1,0 +1,24 @@
+# layout
+
+Controls how the heatmap grid is arranged.
+
+## Options
+- `"default"` — Traditional GitHub-style week-column grid (default)
+- `"monthly"` — One row per month with days 1–31 as columns
+
+## Example
+
+```heatmap-tracker
+heatmapTitle: Monthly View
+layout: monthly
+property: exercise
+```
+
+## Combined with monthsToShow
+
+```heatmap-tracker
+heatmapTitle: Last 3 Months
+layout: monthly
+monthsToShow: 3
+property: exercise
+```

--- a/EXAMPLE_VAULT/Documentation with Examples/3. trackerData parameters/13. dateRange.md
+++ b/EXAMPLE_VAULT/Documentation with Examples/3. trackerData parameters/13. dateRange.md
@@ -1,0 +1,46 @@
+# Date Range Parameters
+
+Control which dates the heatmap displays. These parameters enable partial year views.
+
+## Priority Order
+
+When multiple parameters are set, they are resolved in this order (highest priority first):
+1. `monthsToShow` — shows current month + N previous months
+2. `daysToShow` — shows last N days from today
+3. `startDate` + `endDate` — shows a specific date range
+
+## monthsToShow
+
+Show the current month plus N previous months.
+
+```heatmap-tracker
+heatmapTitle: Last 3 Months
+layout: monthly
+monthsToShow: 3
+property: exercise
+```
+
+- `monthsToShow: 0` shows only the current month
+- `monthsToShow: 3` shows 4 rows (current + 3 prior)
+
+## daysToShow
+
+Show the last N days from today.
+
+```heatmap-tracker
+heatmapTitle: Last 90 Days
+daysToShow: 90
+property: exercise
+```
+
+## startDate / endDate
+
+Show a specific date range (format: YYYY-MM-DD).
+
+```heatmap-tracker
+heatmapTitle: Q1 2026
+layout: monthly
+startDate: 2026-01-01
+endDate: 2026-03-31
+property: exercise
+```

--- a/README.md
+++ b/README.md
@@ -190,6 +190,41 @@ Notes
 - **Default:** `[]`
 - **Description:** Powerful property for calculating and displaying your own insights in `Statistics`. Check this [example](https://github.com/mokkiebear/heatmap-tracker/blob/main/EXAMPLE_VAULT/Documentation%20with%20Examples/3.%20trackerData%20parameters/6.%20insights.md).
 
+---
+
+### `layout`
+- **Type:** `"default" | "monthly"`
+- **Default:** `"default"`
+- **Description:** Controls the heatmap grid arrangement. `"default"` renders the traditional GitHub-style week-column grid. `"monthly"` renders one row per month with days 1–31 as columns, providing a compact calendar-style view.
+
+---
+
+### `monthsToShow`
+- **Type:** `number`
+- **Default:** `undefined` (shows full year)
+- **Description:** Show the current month plus the N previous months. For example, `monthsToShow: 3` displays 4 rows (current month + 3 prior). Takes precedence over `daysToShow` and `startDate`/`endDate`. Best used with `layout: "monthly"`.
+
+---
+
+### `daysToShow`
+- **Type:** `number`
+- **Default:** `undefined` (shows full year)
+- **Description:** Show the last N days from today. Takes precedence over `startDate`/`endDate` but is overridden by `monthsToShow`.
+
+---
+
+### `startDate`
+- **Type:** `string` (format: `YYYY-MM-DD`)
+- **Default:** `undefined`
+- **Description:** First date to display. Must be used together with `endDate`. Overridden by `daysToShow` or `monthsToShow`.
+
+---
+
+### `endDate`
+- **Type:** `string` (format: `YYYY-MM-DD`)
+- **Default:** `undefined`
+- **Description:** Last date to display. Must be used together with `startDate`. Overridden by `daysToShow` or `monthsToShow`.
+
 
 <img src="https://raw.githubusercontent.com/mokkiebear/heatmap-tracker/refs/heads/main/public/two-mac-mockup.png" />
 
@@ -256,6 +291,11 @@ To be used with [Obsidian Dataview](https://blacksmithgu.github.io/obsidian-data
     <summary>9. <b>Customizable Font.</b> Use your favorite font with this plugin.</summary>
     <p>Additionally, you can use <code>HTML</code> to further customize the plugin's appearance.</p>
     <img width="400" alt="Font Customization" src="https://github.com/user-attachments/assets/09f79cbe-45e8-477e-8111-631f34b98cdb" />
+</details>
+
+<details>
+    <summary>10. <b>Monthly Layout.</b> Display your heatmap as a compact calendar with one row per month.</summary>
+    <p>Set <code>layout: "monthly"</code> to switch from the default GitHub-style grid to a calendar-style view with days 1–31 as columns. Combine with <code>monthsToShow</code> to display only recent months.</p>
 </details>
 
 <img src="https://raw.githubusercontent.com/mokkiebear/heatmap-tracker/refs/heads/main/public/mac-mockup-dark.png" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,10 +18,13 @@ const DocumentationView = lazy(
 );
 
 const LegendView = lazy(() => import("./views/LegendView/LegendView"));
+const MonthlyHeatmapView = lazy(
+  () => import("./views/MonthlyHeatmapView/MonthlyHeatmapView")
+);
 
 function ReactApp() {
   const { i18n } = useTranslation();
-  const { currentYear, settings, view } = useHeatmapContext();
+  const { currentYear, settings, view, trackerData } = useHeatmapContext();
 
   useEffect(() => {
     i18n.changeLanguage(settings.language);
@@ -30,7 +33,9 @@ function ReactApp() {
   let content;
   switch (view) {
     case IHeatmapView.HeatmapTracker:
-      content = <HeatmapTrackerView />;
+      content = trackerData.layout === "monthly"
+        ? <MonthlyHeatmapView />
+        : <HeatmapTrackerView />;
       break;
     case IHeatmapView.HeatmapTrackerStatistics:
       content = <StatisticsView />;

--- a/src/components/HeatmapHeader/HeatmapHeader.tsx
+++ b/src/components/HeatmapHeader/HeatmapHeader.tsx
@@ -4,7 +4,7 @@ import { HeatmapTabs } from "../HeatmapTabs/HeatmapTabs";
 
 export function HeatmapHeader() {
   const { t } = useTranslation();
-  const { currentYear, setCurrentYear, trackerData } = useHeatmapContext();
+  const { currentYear, setCurrentYear, trackerData, dateRange } = useHeatmapContext();
 
   function onArrowBackClick() {
     setCurrentYear((prev) => prev - 1);
@@ -18,7 +18,7 @@ export function HeatmapHeader() {
     <div className="heatmap-tracker-header">
       <div className="heatmap-tracker-header__main-row">
         <div className="heatmap-tracker-header__navigation">
-          {trackerData?.ui?.hideYear ? null : (
+          {trackerData?.ui?.hideYear || dateRange ? null : (
             <>
               <button
                 className="heatmap-tracker-arrow left clickable-icon"

--- a/src/context/heatmap/heatmap.context.tsx
+++ b/src/context/heatmap/heatmap.context.tsx
@@ -10,8 +10,8 @@ import {
 } from "src/types";
 import { getColors } from "src/utils/colors";
 import { getBoxes, getEntriesForYear } from "src/utils/core";
-import { getCurrentFullYear } from "src/utils/date";
-import { fillEntriesWithIntensity } from "src/utils/intensity";
+import { DateRange, getCurrentFullYear, resolveDateRange } from "src/utils/date";
+import { fillEntriesWithIntensity, fillEntriesWithIntensityByDate } from "src/utils/intensity";
 
 export const HeatmapContext = createContext<HeatmapContextProps | null>(null);
 
@@ -37,6 +37,13 @@ export function HeatmapProvider({
 
   const [currentYear, setCurrentYear] = useState(_defaultYear);
 
+  const isMonthlyLayout = trackerData.layout === "monthly";
+
+  const dateRange = useMemo<DateRange | null>(
+    () => resolveDateRange(trackerData.startDate, trackerData.endDate, trackerData.daysToShow, trackerData.monthsToShow),
+    [trackerData.startDate, trackerData.endDate, trackerData.daysToShow, trackerData.monthsToShow],
+  );
+
   const allFilteredEntries = useMemo(() => {
     return trackerData.entries.filter((e) => {
       if (trackerData.intensityConfig?.excludeFalsy && !e.intensity) {
@@ -47,8 +54,10 @@ export function HeatmapProvider({
   }, [trackerData.entries, trackerData.intensityConfig?.excludeFalsy]);
 
   const currentYearEntries = useMemo(
-    () => getEntriesForYear(allFilteredEntries, currentYear),
-    [allFilteredEntries, currentYear],
+    () => (isMonthlyLayout && dateRange)
+      ? allFilteredEntries
+      : getEntriesForYear(allFilteredEntries, currentYear),
+    [allFilteredEntries, currentYear, isMonthlyLayout, dateRange],
   );
 
   const mergedTrackerData: TrackerData = useMemo(() => {
@@ -73,16 +82,31 @@ export function HeatmapProvider({
     [currentYearEntries, mergedTrackerData.intensityConfig, colorsList],
   );
 
+  const entriesWithIntensityByDate = useMemo(
+    () =>
+      isMonthlyLayout
+        ? fillEntriesWithIntensityByDate(
+            currentYearEntries,
+            mergedTrackerData.intensityConfig,
+            colorsList,
+          )
+        : {},
+    [isMonthlyLayout, currentYearEntries, mergedTrackerData.intensityConfig, colorsList],
+  );
+
   const boxes = useMemo(
     () =>
-      getBoxes(
-        currentYear,
-        entriesWithIntensity,
-        colorsList,
-        mergedTrackerData,
-        settings,
-      ),
+      isMonthlyLayout
+        ? [] // Monthly layout builds its own grid, not boxes
+        : getBoxes(
+            currentYear,
+            entriesWithIntensity,
+            colorsList,
+            mergedTrackerData,
+            settings,
+          ),
     [
+      isMonthlyLayout,
       currentYear,
       entriesWithIntensity,
       colorsList,
@@ -101,8 +125,10 @@ export function HeatmapProvider({
         view,
         colorsList,
         entriesWithIntensity,
+        entriesWithIntensityByDate,
         allFilteredEntries,
         boxes,
+        dateRange,
         intensityConfig: trackerData.intensityConfig,
         setCurrentYear,
         setView,
@@ -122,8 +148,10 @@ interface HeatmapContextProps {
   view: IHeatmapView;
   colorsList: ColorsList;
   entriesWithIntensity: Record<number, Entry>;
+  entriesWithIntensityByDate: Record<string, Entry>;
   allFilteredEntries: Entry[];
   boxes: Box[];
+  dateRange: DateRange | null;
   setCurrentYear: React.Dispatch<React.SetStateAction<number>>;
   setView: React.Dispatch<React.SetStateAction<IHeatmapView>>;
 }

--- a/src/schemas/trackerData.schema.ts
+++ b/src/schemas/trackerData.schema.ts
@@ -39,4 +39,30 @@ export const TrackerDataSchema = z.object({
    */
   disableFileCreation: z.boolean().optional(),
   ui: UISchema.optional(),
+
+  /**
+   * Layout mode for the heatmap.
+   * "default" — traditional week-column grid (GitHub-style)
+   * "monthly" — one row per month, days 1–31 as columns
+   */
+  layout: z.enum(["default", "monthly"]).optional(),
+  /**
+   * First date to display (format: YYYY-MM-DD). Used for partial year views.
+   */
+  startDate: z.string().optional(),
+  /**
+   * Last date to display (format: YYYY-MM-DD). Used for partial year views.
+   */
+  endDate: z.string().optional(),
+  /**
+   * Show last N days from today. Alternative to startDate/endDate.
+   * Takes precedence over startDate/endDate if both are provided.
+   */
+  daysToShow: z.number().optional(),
+  /**
+   * Show the current month plus the N previous months.
+   * e.g. monthsToShow: 3 shows current month + 3 prior = 4 rows.
+   * Takes precedence over daysToShow and startDate/endDate.
+   */
+  monthsToShow: z.number().optional(),
 });

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -10,6 +10,7 @@
 @use './styles/heatmap-tracker-box.scss';
 @use './styles/heatmap-tracker-boxes.scss';
 @use './styles/heatmap-tracker-week-nums.scss';
+@use './styles/heatmap-monthly.scss';
 
 .heatmap-tracker__container,
 .heatmap-tracker-legend,

--- a/src/styles/heatmap-monthly.scss
+++ b/src/styles/heatmap-monthly.scss
@@ -1,0 +1,45 @@
+.heatmap-tracker.monthly-heatmap {
+  display: block;
+  width: 100%;
+  padding: 8px 4px;
+  overflow: hidden;
+}
+
+.monthly-heatmap-grid {
+  display: grid;
+  grid-template-columns: auto repeat(31, minmax(0, 1fr));
+  gap: 1px;
+  align-items: center;
+}
+
+.monthly-heatmap-label {
+  text-align: right;
+  padding-right: 0.4em;
+  font-size: clamp(0.55em, 1.5vw, 0.75em);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.monthly-heatmap-day-header {
+  text-align: center;
+  font-size: clamp(0.5em, 1.2vw, 0.65em);
+  color: var(--text-muted);
+  padding-bottom: 2px;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.monthly-heatmap-empty {
+  aspect-ratio: 1;
+  width: 100%;
+}
+
+.monthly-heatmap .heatmap-tracker-box {
+  aspect-ratio: 1;
+  width: 100%;
+
+  &:hover {
+    transform: none;
+    opacity: 0.75;
+  }
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -90,3 +90,60 @@ export function isSameDate(d1: Date, d2: Date): boolean {
     d1.getUTCDate() === d2.getUTCDate()
   );
 }
+
+export function parseUTCDate(dateStr: string): Date {
+  const match = dateStr.match(/(\d{4})[/-](\d{1,2})[/-](\d{1,2})/);
+  if (match) {
+    const [, year, month, day] = match;
+    return new Date(Date.UTC(parseInt(year), parseInt(month) - 1, parseInt(day)));
+  }
+  const date = new Date(dateStr);
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+export function addDays(date: Date, days: number): Date {
+  const result = new Date(date.getTime());
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+}
+
+export interface DateRange {
+  start: Date;
+  end: Date;
+}
+
+export function resolveDateRange(
+  startDate?: string,
+  endDate?: string,
+  daysToShow?: number,
+  monthsToShow?: number,
+): DateRange | null {
+  if (monthsToShow !== undefined && monthsToShow >= 0) {
+    const today = getToday();
+    const endOfMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth() + 1, 0));
+    const startOfRange = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth() - monthsToShow, 1));
+    return { start: startOfRange, end: endOfMonth };
+  }
+
+  if (daysToShow !== undefined && daysToShow > 0) {
+    const today = getToday();
+    return {
+      start: addDays(today, -(daysToShow - 1)),
+      end: today,
+    };
+  }
+
+  if (startDate && endDate) {
+    const start = parseUTCDate(startDate);
+    const end = parseUTCDate(endDate);
+    if (!isNaN(start.getTime()) && !isNaN(end.getTime()) && start <= end) {
+      return { start, end };
+    }
+  }
+
+  return null;
+}
+
+export function getDaysInMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+}

--- a/src/utils/intensity.ts
+++ b/src/utils/intensity.ts
@@ -1,6 +1,6 @@
 import { ColorsList, Entry, IntensityConfig } from "src/types";
 import { mapRange } from "./core";
-import { getDayOfYear } from "./date";
+import { formatDateToISO8601, getDayOfYear, parseUTCDate } from "./date";
 
 /**
  * Returns an array of unique intensities from the given entries.
@@ -222,6 +222,69 @@ export function fillEntriesWithIntensity(
   });
 
   return entriesByDay;
+}
+
+/**
+ * Like fillEntriesWithIntensity but keyed by ISO date string (YYYY-MM-DD)
+ * instead of day-of-year. Supports date ranges spanning multiple years.
+ */
+export function fillEntriesWithIntensityByDate(
+  entries: Entry[],
+  intensityConfig: IntensityConfig,
+  colorsList: ColorsList,
+): Record<string, Entry> {
+  const entriesByDate: Record<string, Entry> = {};
+  const aggregated: Record<string, Entry> = {};
+
+  entries.forEach((e) => {
+    if (intensityConfig.excludeFalsy && !e.intensity) return;
+
+    const utcDate = parseUTCDate(e.date);
+    const dateKey = formatDateToISO8601(utcDate);
+    if (!dateKey) return;
+
+    if (aggregated[dateKey]) {
+      const existing = aggregated[dateKey];
+      aggregated[dateKey] = {
+        ...existing,
+        intensity: (existing.intensity || 0) + (e.intensity || 0),
+        content:
+          existing.content && e.content
+            ? `${existing.content}\n${e.content}`
+            : existing.content || e.content,
+      };
+    } else {
+      aggregated[dateKey] = { ...e };
+    }
+  });
+
+  const intensities = getEntriesIntensities(Object.values(aggregated));
+  const intensitiesMap = getIntensitiesInfo(intensities, intensityConfig, colorsList);
+  const [minimumIntensity, maximumIntensity] = getMinMaxIntensities(intensities, intensityConfig);
+
+  Object.entries(aggregated).forEach(([dateKey, e]) => {
+    const currentIntensity = e.intensity ?? intensityConfig.defaultIntensity;
+    const foundIntensityInfo = intensitiesMap.find(
+      (o) => currentIntensity >= o.min && currentIntensity <= o.max,
+    );
+
+    let newIntensity: number | undefined;
+    if (foundIntensityInfo) {
+      newIntensity = foundIntensityInfo.intensity;
+    } else if (intensityConfig.showOutOfRange && currentIntensity !== 0) {
+      newIntensity = Math.round(
+        mapRange(currentIntensity, minimumIntensity, maximumIntensity, 1, colorsList.length),
+      );
+    }
+
+    entriesByDate[dateKey] = {
+      ...e,
+      value: e.intensity,
+      intensity: newIntensity,
+    };
+  });
+
+  return entriesByDate;
 }
 
 export function getMinMaxIntensities(

--- a/src/views/MonthlyHeatmapView/MonthlyHeatmapView.tsx
+++ b/src/views/MonthlyHeatmapView/MonthlyHeatmapView.tsx
@@ -1,0 +1,133 @@
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useHeatmapContext } from "src/context/heatmap/heatmap.context";
+import { HeatmapBox } from "src/components/HeatmapBox/HeatmapBox";
+import { Box } from "src/types";
+import { getDaysInMonth, formatDateToISO8601, getToday, isSameDate } from "src/utils/date";
+
+interface MonthRow {
+  year: number;
+  month: number;
+  label: string;
+  boxes: (Box | null)[];
+}
+
+const MONTH_KEYS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+const DAY_NUMBERS = Array.from({ length: 31 }, (_, i) => i + 1);
+
+function MonthlyHeatmapView() {
+  const { t } = useTranslation();
+  const {
+    currentYear,
+    dateRange,
+    entriesWithIntensityByDate,
+    colorsList,
+    trackerData,
+  } = useHeatmapContext();
+
+  const rows = useMemo<MonthRow[]>(() => {
+    const todayDate = getToday();
+    const result: MonthRow[] = [];
+
+    let startMonth: number, startYear: number, endMonth: number, endYear: number;
+
+    if (dateRange) {
+      startYear = dateRange.start.getUTCFullYear();
+      startMonth = dateRange.start.getUTCMonth();
+      endYear = dateRange.end.getUTCFullYear();
+      endMonth = dateRange.end.getUTCMonth();
+    } else {
+      startYear = currentYear;
+      startMonth = 0;
+      endYear = currentYear;
+      endMonth = 11;
+    }
+
+    let y = startYear;
+    let m = startMonth;
+    while (y < endYear || (y === endYear && m <= endMonth)) {
+      const daysInMonth = getDaysInMonth(y, m);
+      const boxes: (Box | null)[] = [];
+
+      for (let day = 1; day <= 31; day++) {
+        if (day > daysInMonth) {
+          boxes.push(null);
+          continue;
+        }
+
+        const currentDate = new Date(Date.UTC(y, m, day));
+        const dateKey = formatDateToISO8601(currentDate);
+        const box: Box = {};
+
+        box.date = dateKey ?? undefined;
+
+        if (isSameDate(currentDate, todayDate)) {
+          box.isToday = true;
+          box.showBorder = trackerData.showCurrentDayBorder;
+        }
+
+        if (dateKey && entriesWithIntensityByDate[dateKey]) {
+          box.hasData = true;
+          const entry = entriesWithIntensityByDate[dateKey];
+          box.content = entry.content || undefined;
+          box.filePath = entry.filePath || undefined;
+          box.customHref = entry.customHref || undefined;
+          box.backgroundColor =
+            entry.customColor ??
+            (entry.intensity !== undefined
+              ? colorsList[entry.intensity - 1]
+              : undefined);
+        } else {
+          box.hasData = false;
+        }
+
+        boxes.push(box);
+      }
+
+      const label = t(`monthsShort.${MONTH_KEYS[m]}`);
+      result.push({ year: y, month: m, label, boxes });
+
+      m++;
+      if (m > 11) {
+        m = 0;
+        y++;
+      }
+    }
+
+    return result;
+  }, [currentYear, dateRange, entriesWithIntensityByDate, colorsList, trackerData, t]);
+
+  return (
+    <div className="heatmap-tracker monthly-heatmap">
+      <div className="monthly-heatmap-grid">
+        {/* Header row: empty cell + day numbers */}
+        <div className="monthly-heatmap-label monthly-heatmap-header-label"></div>
+        {DAY_NUMBERS.map((d) => (
+          <div key={`h-${d}`} className="monthly-heatmap-day-header">{d}</div>
+        ))}
+
+        {/* Month rows */}
+        {rows.map((row) => (
+          <React.Fragment key={`row-${row.year}-${row.month}`}>
+            <div className="monthly-heatmap-label">
+              {row.label}
+            </div>
+            {row.boxes.map((box, i) =>
+              box ? (
+                <HeatmapBox key={`${row.year}-${row.month}-${i}`} box={box} />
+              ) : (
+                <div key={`empty-${row.year}-${row.month}-${i}`} className="monthly-heatmap-empty" />
+              ),
+            )}
+          </React.Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default MonthlyHeatmapView;


### PR DESCRIPTION
Addresses: https://github.com/mokkiebear/heatmap-tracker/issues/32

Adds a new "monthly" layout that renders one row per month with days 1-31 as columns, providing a compact calendar-style view. Supports partial year display via monthsToShow, daysToShow, or explicit startDate/endDate params. Includes README, CHANGELOG, and EXAMPLE_VAULT parameter documentation.

Done with Claude Code, just to scratch my own itch. Sharing in case it's useful to anyone.  ¯\_(ツ)_/¯

