### PR TITLE
fix: entries with weekday-suffixed filenames not showing in heatmap

### DIFF
--- a/src/utils/__tests__/core.spec.ts
+++ b/src/utils/__tests__/core.spec.ts
@@ -223,6 +223,18 @@ describe('getEntriesForYear', () => {
     expect(getEntriesForYear(entries, 2025)).toEqual([{ date: '2025-01-01T00:00:00Z' }]);
   });
 
+  it('should include entries whose filenames have a weekday suffix (issue #89)', () => {
+    const entries: Entry[] = [
+      { date: '2026-06-24-Wednesday' },
+      { date: '2026-06-25-Thursday' },
+      { date: '2025-06-24-Tuesday' },
+    ];
+    expect(getEntriesForYear(entries, 2026)).toEqual([
+      { date: '2026-06-24-Wednesday' },
+      { date: '2026-06-25-Thursday' },
+    ]);
+  });
+
   it('should handle entries with null or undefined dates', () => {
     const entries: Entry[] = [
       { date: null as unknown as string },

--- a/src/utils/__tests__/date.spec.ts
+++ b/src/utils/__tests__/date.spec.ts
@@ -68,6 +68,14 @@ describe('isValidDate', () => {
   test('Valid Date in Different Format', () => {
     expect(isValidDate('12/31/2021')).toBe(true);
   });
+
+  test('Date String with Weekday Suffix (e.g. Daily Notes YYYY-MM-DD-dddd format)', () => {
+    expect(isValidDate('2026-06-24-Wednesday')).toBe(true);
+  });
+
+  test('Null Date', () => {
+    expect(isValidDate(null as unknown as string)).toBe(false);
+  });
 });
 
 describe('getDayOfYear', () => {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,6 +1,8 @@
 export function isValidDate(dateString: string): boolean {
-  const date = new Date(dateString);
-  return !isNaN(date.getTime());
+  if (!dateString) {
+    return false;
+  }
+  return !isNaN(parseUTCDate(dateString).getTime());
 }
 
 export function getDayOfYear(date: Date): number {
@@ -76,7 +78,7 @@ export function formatDateToISO8601(date: Date | null): string | null {
 }
 
 export function getFullYear(date: string) {
-  return new Date(date).getUTCFullYear();
+  return parseUTCDate(date).getUTCFullYear();
 }
 
 export function getCurrentFullYear() {


### PR DESCRIPTION
## Summary
- `isValidDate` and `getFullYear` (`src/utils/date.ts`) used raw `new Date(string)` parsing, so filenames like `2026-06-24-Wednesday` (a common Daily Notes format such as `YYYY-MM-DD-dddd`) parsed as `Invalid Date`.
- `getEntriesForYear` (`src/utils/core.ts`) filters entries by year *before* the tolerant regex-based `parseUTCDate` (already used by the coloring path in `intensity.ts`) gets a chance to run, so these entries were silently dropped — Dataview would see the notes, but the heatmap stayed blank.
- Both helpers now delegate to the same `parseUTCDate` extraction the rendering path already relies on, so filtering and coloring agree on what counts as a valid date.

Closes #89

## Test plan
- [x] `npm test` — all 13 suites / 162 tests pass
- [x] `npm run test:utc` / `npm run test:usa` — pass under both UTC and America/New_York timezones
- [x] `npm run type-check` — clean
- [x] Added regression tests in `date.spec.ts` and `core.spec.ts` covering weekday-suffixed filenames (e.g. `2026-06-24-Wednesday`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)