### PR TITLE
fix: harden heatmap box grid gap against CSS snippet overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Heatmap box grid spacing (`row-gap`/`column-gap`) could be collapsed to `0` by community CSS snippets that reset spacing globally, making adjacent day-boxes touch and look like a single box rendered with two colors ([#83](https://github.com/mokkiebear/heatmap-tracker/issues/83)).
 
 ## [2.6.0] - 2026-07-03
 ### Added

--- a/src/styles/heatmap-tracker-boxes.scss
+++ b/src/styles/heatmap-tracker-boxes.scss
@@ -5,8 +5,12 @@
   grid-template-columns: repeat(53, var(--heatmap-tracker-box-size));
   grid-template-rows: repeat(7, var(--heatmap-tracker-box-size));
   grid-column: 1;
-  row-gap: var(--heatmap-tracker-box-gap);
-  column-gap: var(--heatmap-tracker-box-gap);
+  // !important guards against community CSS snippets that reset spacing
+  // globally (e.g. "compact UI" snippets doing `gap: 0 !important`), which
+  // would otherwise make adjacent day-boxes touch and look like a single
+  // box split into two colors.
+  row-gap: var(--heatmap-tracker-box-gap) !important;
+  column-gap: var(--heatmap-tracker-box-gap) !important;
 }
 
 /* Separate Months */


### PR DESCRIPTION
Adds !important to row-gap/column-gap in .heatmap-tracker-boxes so community "compact UI" CSS snippets that reset gap globally can't collapse it to 0. When that happens, adjacent day-boxes touch and look like a single box rendered with two colors (reported in #83).