### PR TITLE
Contain heatmap box content against injected plugin decorations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Heatmap boxes now clip and contain their content (`overflow: hidden`, `contain: layout paint`) so icons/buttons injected by other community plugins (e.g. Meta Data Menu decorating internal links) can no longer blow up box size and break the whole grid layout ([#41](https://github.com/mokkiebear/heatmap-tracker/issues/41)).
 
 ## [2.6.1] - 2026-07-04
 ### Fixed

--- a/src/styles/heatmap-tracker-box.scss
+++ b/src/styles/heatmap-tracker-box.scss
@@ -5,6 +5,11 @@
   background-color: #ebedf0;
   transition: transform 0.2s, border 0.2s;
   aspect-ratio: 1;
+  // Other community plugins (e.g. Meta Data Menu) decorate internal links
+  // with their own icons/buttons. Without containment, an oversized
+  // injected element blows out the box and breaks the whole grid layout.
+  overflow: hidden;
+  contain: layout paint;
 
   &:hover {
     transform: scale(1.4);


### PR DESCRIPTION
## Summary
- Adds `overflow: hidden` and `contain: layout paint` to `.heatmap-tracker-box` so content injected by other community plugins can't blow up box size and break the grid layout.

## Why
Investigating #41 ("Problems displaying with MetaData menu"): the reporter's screenshot shows a huge grid of oversized icons that has completely displaced the heatmap, while a correctly-sized heatmap grid still renders further down the page. The Meta Data Menu plugin decorates internal links with a small icon/button, and it applies that decoration to the `<a class="internal-link">` inside every one of our day-boxes ([HeatmapBox.tsx](src/components/HeatmapBox/HeatmapBox.tsx)).

The reason it explodes visually rather than just showing a small badge: neither `.heatmap-tracker-box` nor `.heatmap-tracker-content` previously constrained child content size or clipped overflow — `overflow: hidden` was only set on the outer `.heatmap-tracker__container`. An icon sized for a normal line of text is much larger than our 12px box, so it blew out the box and the whole grid collapsed into browser default flow-wrapping.

This is the same class of problem as #83 (fixed in #92): other plugins can freely mutate/decorate the DOM inside elements we render, so we need to defensively contain our own layout rather than assume nothing else touches it.

## Test plan
- [x] `npm run build` — succeeds, `overflow:hidden;contain:layout paint` present in compiled `build/styles.css`
- [x] `npm test` — 219 passed, 1 skipped, no regressions
- [ ] Reporter to confirm this resolves the layout break in #41 on their end (root cause is a strong hypothesis based on code + screenshot analysis, not a live repro with Meta Data Menu installed)

Related: #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)