### PR TITLE
Improve export legend editor and row-view grid layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Export tab: redesigned the legend editor. Intensity colors can now be combined into a single gradient row, with a gear icon for setting each color’s day-count weight and fixed value. Category visibility now uses a three-state toggle: shown everywhere, hidden from summaries, or fully hidden. Drag-to-reorder interactions are smoother and provide clearer visual feedback. Refresh and reset functions are redesigned and they now behave more intuitively.
+- Export tab: redesigned the DatePicker.
+
+### Fixed
+- Export tab: month labels in the weeks-as-rows layout would no longer overlap the week start dates.
 
 ## [2.7.0] - 2026-07-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Every heatmap has an **Export** tab alongside Heatmap Tracker / Statistics / Leg
 - **Layout**: "Weeks as columns" or "Weeks as rows", rendered pixel-for-pixel like the heatmap itself — including exact day-level month-splitting (with a year label whenever the range crosses a year boundary) and, when a date range is too wide/tall for one grid, automatic wrapping into multiple bands, evenly split rather than front-loading one band and leaving a small leftover.
 - **Date range**: pick start/end dates directly, or jump to a range with a preset — Logged (the full span of your tracked data), Last year, Year to date, Last month, or Month to date.
 - **Display options**: which day the week starts on, whether to show each week's start date, split the grid by month, show month labels, and hide weekends.
-- **Legend editor**: colors are pre-populated from what's actually used in your data, so you just fill in what each one means. Reorder entries by drag-and-drop, and toggle per-category whether it's counted in the summary line.
+- **Legend editor**: colors are pre-populated from what's actually used in your data, so you just fill in what each one means. Reorder entries by drag-and-drop, and toggle each category's visibility — shown everywhere, summary-only, or hidden entirely. Optionally combine the intensity colors into a single gradient swatch with one shared label and count, instead of a row per color.
 - **Summary line**: a compact, customizable breakdown like `Workday: 22 · Leave: 1 · Rest day but worked: 1` with a total (e.g. `Total hours: 169`) — or hide the breakdown, the total, or all values entirely.
 - **Output**: save as a Markdown note or a self-contained HTML file, to whichever folder in your vault you choose.
 

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,0 +1,339 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { getShiftedWeekdays } from "src/utils/date";
+import { CalendarIcon } from "src/components/icons/CalendarIcon";
+import { ChevronLeftIcon } from "src/components/icons/ChevronLeftIcon";
+import { ChevronRightIcon } from "src/components/icons/ChevronRightIcon";
+import { buildDayGrid, parseISO, parseTypedISO, todayParts, toISO } from "src/components/DatePicker/dateGrid";
+
+const WEEKDAY_LETTERS = ["S", "M", "T", "W", "T", "F", "S"];
+const MONTH_SHORT_LABELS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+// How many years the year-grid pages by per prev/next click — a full page of
+// the 12 shown, minus the one-year overlap at each edge (see the year-level
+// render below), matching how the day-grid also always advances by exactly
+// one full month regardless of how many overflow days it shows.
+const YEAR_PAGE_STEP = 10;
+
+const MONTH_FORMATTER = new Intl.DateTimeFormat(undefined, { month: "long", year: "numeric", timeZone: "UTC" });
+const TRIGGER_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  timeZone: "UTC",
+});
+
+type Level = "day" | "month" | "year";
+
+interface ViewState {
+  year: number;
+  /** 0-indexed. */
+  month: number;
+  level: Level;
+}
+
+export interface DatePickerProps {
+  /** ISO `yyyy-mm-dd`, or `""` for unset. */
+  value: string;
+  onChange: (value: string) => void;
+  /** 0 (Sunday) – 6 (Saturday); the day-grid's leftmost column and week-row layout follow this. */
+  weekStartDay: number;
+  ariaLabel?: string;
+}
+
+function classNames(...parts: Array<string | false | undefined>): string {
+  return parts.filter(Boolean).join(" ");
+}
+
+function initialView(value: string): ViewState {
+  const parsed = parseISO(value) ?? todayParts();
+  return { year: parsed.year, month: parsed.month, level: "day" };
+}
+
+/**
+ * A styled stand-in for `<input type="date">`, matching the plugin's own
+ * theme (the native picker can't be restyled at all — not even accent
+ * color). Clicking the header label drills up a level: the day view's label
+ * opens a 12-month grid for the year, whose own label opens a 12-year grid
+ * for jumping across decades — rather than only ever stepping one month at a
+ * time. The trigger is a real text input, so a known date (`yyyy-mm-dd`) can
+ * be typed directly instead of always navigating the grid to it.
+ */
+export function DatePicker({ value, onChange, weekStartDay, ariaLabel }: DatePickerProps) {
+  const { t } = useTranslation();
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [isFlipped, setIsFlipped] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editText, setEditText] = useState("");
+  const [view, setView] = useState<ViewState>(() => initialView(value));
+
+  const shiftedWeekdayLabels = getShiftedWeekdays(WEEKDAY_LETTERS, weekStartDay);
+  const selected = parseISO(value);
+  const today = todayParts();
+
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+
+    function handlePointerDown(e: PointerEvent) {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [isOpen]);
+
+  useLayoutEffect(() => {
+    if (!isOpen || !panelRef.current) return;
+    // Right-anchored triggers (e.g. the "to" side of a date range) have less
+    // room to their right on narrow viewports — flip the panel to hang off
+    // the trigger's right edge instead of its left if it would otherwise
+    // spill past the viewport.
+    setIsFlipped(false);
+    const rect = panelRef.current.getBoundingClientRect();
+    if (rect.right > window.innerWidth) {
+      setIsFlipped(true);
+    }
+  }, [isOpen, view.level]);
+
+  function openPanel() {
+    // Only (re-)sync the displayed month/year to the committed value when
+    // actually opening from closed — if this fires again while already open
+    // (e.g. a redundant focus event during in-panel navigation), it must not
+    // clobber whatever month/year the user is mid-navigation to.
+    if (!isOpen) {
+      setView(initialView(value));
+    }
+    setIsOpen(true);
+  }
+
+  function commit(iso: string) {
+    onChange(iso);
+    setIsOpen(false);
+    setIsEditing(false);
+  }
+
+  function handleCalendarButtonClick() {
+    if (isOpen) setIsOpen(false);
+    else openPanel();
+  }
+
+  function handleFocus() {
+    setEditText(value);
+    setIsEditing(true);
+    openPanel();
+  }
+
+  function commitTypedValue() {
+    const trimmed = editText.trim();
+    if (trimmed === "") {
+      onChange("");
+    } else {
+      const parsed = parseTypedISO(trimmed);
+      if (parsed) onChange(parsed);
+      // Unparseable: discard it, the trigger label re-renders from `value`.
+    }
+    setIsEditing(false);
+  }
+
+  function handleInputBlur(e: React.FocusEvent<HTMLInputElement>) {
+    // Blur fires before click when focus moves from the input to a nav
+    // button/day/month/year cell within this same panel - if that's where
+    // focus is headed, this isn't the user leaving the widget, just
+    // navigating it. Committing here would call onChange (even with an
+    // unchanged value) and force a parent re-render in the middle of that
+    // click, which can suppress the click having any visible effect.
+    const nextFocused = e.relatedTarget as Node | null;
+    if (nextFocused && wrapRef.current?.contains(nextFocused)) return;
+    commitTypedValue();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Escape") {
+      setIsEditing(false);
+      setIsOpen(false);
+      inputRef.current?.blur();
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      commitTypedValue();
+      setIsOpen(false);
+      inputRef.current?.blur();
+    }
+  }
+
+  function step(dir: number) {
+    setView((prev) => {
+      if (prev.level === "day") {
+        let { year, month } = prev;
+        month += dir;
+        if (month < 0) {
+          month = 11;
+          year -= 1;
+        } else if (month > 11) {
+          month = 0;
+          year += 1;
+        }
+        return { ...prev, year, month };
+      }
+      if (prev.level === "month") {
+        return { ...prev, year: prev.year + dir };
+      }
+      return { ...prev, year: prev.year + dir * YEAR_PAGE_STEP };
+    });
+  }
+
+  function drillUp() {
+    setView((prev) => ({ ...prev, level: prev.level === "month" ? "year" : "month" }));
+  }
+
+  const displayValue = isEditing
+    ? editText
+    : value && selected
+      ? TRIGGER_FORMATTER.format(new Date(Date.UTC(selected.year, selected.month, selected.day)))
+      : "";
+
+  const navLabels: Record<Level, [string, string]> = {
+    day: [t("datePicker.previousMonth"), t("datePicker.nextMonth")],
+    month: [t("datePicker.previousYear"), t("datePicker.nextYear")],
+    year: [t("datePicker.previousDecade"), t("datePicker.nextDecade")],
+  };
+  const [prevLabel, nextLabel] = navLabels[view.level];
+
+  const decadeStart = Math.floor(view.year / 10) * 10;
+
+  return (
+    <div className={classNames("date-picker", isOpen && "is-open")} ref={wrapRef}>
+      <div className="date-picker__trigger">
+        <input
+          ref={inputRef}
+          type="text"
+          className="date-picker__input"
+          aria-label={ariaLabel}
+          autoComplete="off"
+          placeholder="yyyy-mm-dd"
+          value={displayValue}
+          onFocus={handleFocus}
+          onBlur={handleInputBlur}
+          onChange={(e) => setEditText(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <button
+          type="button"
+          className="date-picker__calendar-btn"
+          tabIndex={-1}
+          aria-haspopup="dialog"
+          aria-expanded={isOpen}
+          aria-label={ariaLabel ? `${t("datePicker.openCalendar")}: ${ariaLabel}` : t("datePicker.openCalendar")}
+          onClick={handleCalendarButtonClick}
+        >
+          <CalendarIcon />
+        </button>
+      </div>
+
+      {isOpen && (
+        <div className={classNames("date-picker__panel", isFlipped && "is-flipped")} ref={panelRef}>
+          <div className="date-picker__header">
+            <button type="button" className="date-picker__nav-btn" aria-label={prevLabel} onClick={() => step(-1)}>
+              <ChevronLeftIcon />
+            </button>
+            <button
+              type="button"
+              className={classNames("date-picker__label-btn", view.level === "year" && "is-static")}
+              disabled={view.level === "year"}
+              onClick={drillUp}
+            >
+              {view.level === "day" && MONTH_FORMATTER.format(new Date(Date.UTC(view.year, view.month, 1)))}
+              {view.level === "month" && view.year}
+              {view.level === "year" && `${decadeStart}–${decadeStart + 9}`}
+            </button>
+            <button type="button" className="date-picker__nav-btn" aria-label={nextLabel} onClick={() => step(1)}>
+              <ChevronRightIcon />
+            </button>
+          </div>
+
+          {view.level === "day" && (
+            <>
+              <div className="date-picker__weekdays">
+                {shiftedWeekdayLabels.map((label, i) => (
+                  <span key={i}>{label}</span>
+                ))}
+              </div>
+              <div className="date-picker__grid date-picker__grid--days">
+                {buildDayGrid(view.year, view.month, weekStartDay).map((cell) => (
+                  <button
+                    key={cell.iso}
+                    type="button"
+                    className={classNames(
+                      "date-picker__day",
+                      !cell.inMonth && "is-outside",
+                      cell.iso === toISO(today.year, today.month, today.day) && "is-today",
+                      cell.iso === value && "is-selected",
+                    )}
+                    onClick={() => commit(cell.iso)}
+                  >
+                    {cell.day}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+
+          {view.level === "month" && (
+            <div className="date-picker__grid date-picker__grid--months">
+              {MONTH_SHORT_LABELS.map((label, m) => (
+                <button
+                  key={m}
+                  type="button"
+                  className={classNames(
+                    "date-picker__cell",
+                    view.year === today.year && m === today.month && "is-current",
+                    selected?.year === view.year && selected.month === m && "is-selected",
+                  )}
+                  onClick={() => setView({ year: view.year, month: m, level: "day" })}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {view.level === "year" && (
+            <div className="date-picker__grid date-picker__grid--years">
+              {Array.from({ length: 12 }, (_, i) => decadeStart - 1 + i).map((y) => (
+                <button
+                  key={y}
+                  type="button"
+                  className={classNames(
+                    "date-picker__cell",
+                    (y < decadeStart || y > decadeStart + 9) && "is-outside",
+                    y === today.year && "is-current",
+                    selected?.year === y && "is-selected",
+                  )}
+                  onClick={() => setView({ year: y, month: view.month, level: "month" })}
+                >
+                  {y}
+                </button>
+              ))}
+            </div>
+          )}
+
+          <div className="date-picker__footer">
+            <button type="button" className="date-picker__action" onClick={() => commit("")}>
+              {t("datePicker.clear")}
+            </button>
+            <button
+              type="button"
+              className="date-picker__action"
+              onClick={() => commit(toISO(today.year, today.month, today.day))}
+            >
+              {t("datePicker.today")}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/DatePicker/__tests__/DatePicker.spec.tsx
+++ b/src/components/DatePicker/__tests__/DatePicker.spec.tsx
@@ -1,0 +1,274 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { DatePicker } from "../DatePicker";
+
+jest.mock("react-i18next", () => ({
+  ...jest.requireActual("react-i18next"),
+  useTranslation: jest.fn(() => ({
+    t: (key: string) => key,
+    i18n: { changeLanguage: jest.fn() },
+  })),
+}));
+
+jest.mock("src/utils/date", () => ({
+  ...jest.requireActual("src/utils/date"),
+  getToday: jest.fn(),
+}));
+
+const { getToday } = jest.requireMock("src/utils/date") as { getToday: jest.Mock };
+
+function setToday(iso: string) {
+  const [year, month, day] = iso.split("-").map(Number);
+  getToday.mockReturnValue(new Date(Date.UTC(year, month - 1, day)));
+}
+
+beforeEach(() => {
+  setToday("2026-07-15");
+});
+
+function openPicker(container: HTMLElement) {
+  const button = container.querySelector(".date-picker__calendar-btn") as HTMLElement;
+  fireEvent.click(button);
+}
+
+describe("DatePicker", () => {
+  it("shows the formatted value in the trigger when not focused", () => {
+    render(<DatePicker value="2026-07-13" onChange={jest.fn()} weekStartDay={1} />);
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    expect(input.value).toBe("Jul 13, 2026");
+  });
+
+  it("opens the day grid on the value's month when the calendar button is clicked", () => {
+    const { container } = render(<DatePicker value="2026-07-13" onChange={jest.fn()} weekStartDay={1} />);
+    openPicker(container);
+
+    expect(screen.queryByText("July 2026")).not.toBeNull();
+    expect(container.querySelectorAll(".date-picker__day")).toHaveLength(42);
+  });
+
+  it("starts the weekday header on Monday when weekStartDay is 1", () => {
+    const { container } = render(<DatePicker value="2026-07-13" onChange={jest.fn()} weekStartDay={1} />);
+    openPicker(container);
+
+    const labels = Array.from(container.querySelectorAll(".date-picker__weekdays span")).map((el) => el.textContent);
+    expect(labels[0]).toBe("M");
+  });
+
+  it("starts the weekday header on Sunday when weekStartDay is 0", () => {
+    const { container } = render(<DatePicker value="2026-07-13" onChange={jest.fn()} weekStartDay={0} />);
+    openPicker(container);
+
+    const labels = Array.from(container.querySelectorAll(".date-picker__weekdays span")).map((el) => el.textContent);
+    expect(labels[0]).toBe("S");
+  });
+
+  it("reorders the day grid's columns to match weekStartDay, not just the header labels", () => {
+    // Jul 1, 2026 is a Wednesday. With Monday-start the leading overflow is
+    // Jun 29-30 (2 cells); with Sunday-start it's Jun 28-30 (3 cells) -
+    // moving Jul 1 from the 3rd cell to the 4th.
+    const monday = render(<DatePicker value="2026-07-13" onChange={jest.fn()} weekStartDay={1} />);
+    openPicker(monday.container);
+    const mondayDays = monday.container.querySelectorAll(".date-picker__day");
+    expect(mondayDays[2].textContent).toBe("1");
+    expect(mondayDays[2].classList.contains("is-outside")).toBe(false);
+
+    const sunday = render(<DatePicker value="2026-07-13" onChange={jest.fn()} weekStartDay={0} />);
+    openPicker(sunday.container);
+    const sundayDays = sunday.container.querySelectorAll(".date-picker__day");
+    expect(sundayDays[3].textContent).toBe("1");
+    expect(sundayDays[3].classList.contains("is-outside")).toBe(false);
+  });
+
+  it("calls onChange and closes the panel when a day is picked", () => {
+    const onChange = jest.fn();
+    const { container } = render(<DatePicker value="2026-07-13" onChange={onChange} weekStartDay={1} />);
+    openPicker(container);
+
+    const day20 = Array.from(container.querySelectorAll(".date-picker__day")).find(
+      (el) => el.textContent === "20" && !el.classList.contains("is-outside"),
+    ) as HTMLElement;
+    fireEvent.click(day20);
+
+    expect(onChange).toHaveBeenCalledWith("2026-07-20");
+    expect(container.querySelector(".date-picker__panel")).toBeNull();
+  });
+
+  it("steps to the previous/next month via the nav buttons", () => {
+    const { container } = render(<DatePicker value="2026-07-13" onChange={jest.fn()} weekStartDay={1} />);
+    openPicker(container);
+
+    fireEvent.click(screen.getByLabelText("datePicker.nextMonth"));
+    expect(screen.queryByText("August 2026")).not.toBeNull();
+
+    fireEvent.click(screen.getByLabelText("datePicker.previousMonth"));
+    fireEvent.click(screen.getByLabelText("datePicker.previousMonth"));
+    expect(screen.queryByText("June 2026")).not.toBeNull();
+  });
+
+  it("drills up to month view then year view via the header label, and back down on selection", () => {
+    const { container } = render(<DatePicker value="2026-07-13" onChange={jest.fn()} weekStartDay={1} />);
+    openPicker(container);
+
+    fireEvent.click(screen.getByText("July 2026"));
+    expect(container.querySelectorAll(".date-picker__grid--months .date-picker__cell")).toHaveLength(12);
+
+    fireEvent.click(screen.getByText("2026"));
+    expect(container.querySelectorAll(".date-picker__grid--years .date-picker__cell")).toHaveLength(12);
+    expect(screen.queryByText("2020–2029")).not.toBeNull();
+
+    fireEvent.click(screen.getByText("2030"));
+    expect(container.querySelectorAll(".date-picker__grid--months .date-picker__cell")).toHaveLength(12);
+
+    fireEvent.click(screen.getByText("Mar"));
+    expect(screen.queryByText("March 2030")).not.toBeNull();
+  });
+
+  it("picks the actually-correct date after switching to a distant year and month, not a stale one", () => {
+    // Same journey as above, but instead of just checking the header text,
+    // verify the day grid genuinely re-renders for 2030-03 and that picking
+    // a day fires onChange with a date matching what was actually switched
+    // to (guards against a stale year/month sneaking into the day grid).
+    const onChange = jest.fn();
+    const { container } = render(<DatePicker value="2026-07-13" onChange={onChange} weekStartDay={1} />);
+    openPicker(container);
+
+    fireEvent.click(screen.getByText("July 2026"));
+    fireEvent.click(screen.getByText("2026"));
+    fireEvent.click(screen.getByText("2030"));
+    fireEvent.click(screen.getByText("Mar"));
+
+    const day15 = Array.from(container.querySelectorAll(".date-picker__day")).find(
+      (el) => el.textContent === "15" && !el.classList.contains("is-outside"),
+    ) as HTMLElement;
+    fireEvent.click(day15);
+
+    expect(onChange).toHaveBeenCalledWith("2030-03-15");
+  });
+
+  it("still switches month/year when the input blurs first (real browsers fire blur before click)", () => {
+    // Opening via focusing the input, then clicking a grid cell, blurs the
+    // input BEFORE the cell's click event fires (standard browser event
+    // order) - reproduces that exact sequence instead of only ever using
+    // fireEvent.click, which never fires the preceding blur at all.
+    const onChange = jest.fn();
+    const { container } = render(<DatePicker value="2026-07-13" onChange={onChange} weekStartDay={1} />);
+    const input = screen.getByRole("textbox");
+    fireEvent.focus(input);
+
+    const monthLabel = screen.getByText("July 2026");
+    fireEvent.blur(input, { relatedTarget: monthLabel });
+    fireEvent.click(monthLabel);
+
+    expect(container.querySelectorAll(".date-picker__grid--months .date-picker__cell")).toHaveLength(12);
+
+    const marchCell = screen.getByText("Mar");
+    fireEvent.blur(input, { relatedTarget: marchCell });
+    fireEvent.click(marchCell);
+
+    expect(screen.queryByText("March 2026")).not.toBeNull();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("does not reset the navigated-to month/year if the input is redundantly refocused while already open", () => {
+    const onChange = jest.fn();
+    render(<DatePicker value="2026-07-13" onChange={onChange} weekStartDay={1} />);
+    const input = screen.getByRole("textbox");
+    fireEvent.focus(input);
+
+    fireEvent.click(screen.getByLabelText("datePicker.nextMonth"));
+    expect(screen.queryByText("August 2026")).not.toBeNull();
+
+    // Simulate the input somehow regaining focus while already navigated away.
+    fireEvent.focus(input);
+
+    expect(screen.queryByText("August 2026")).not.toBeNull();
+  });
+
+  it("steps by year at month-level and by decade at year-level", () => {
+    const { container } = render(<DatePicker value="2026-07-13" onChange={jest.fn()} weekStartDay={1} />);
+    openPicker(container);
+
+    fireEvent.click(screen.getByText("July 2026")); // -> month level, year 2026
+    fireEvent.click(screen.getByLabelText("datePicker.nextYear"));
+    expect(screen.queryByText("2027")).not.toBeNull();
+
+    fireEvent.click(screen.getByText("2027")); // -> year level, decade around 2027
+    expect(screen.queryByText("2020–2029")).not.toBeNull();
+
+    fireEvent.click(screen.getByLabelText("datePicker.nextDecade"));
+    expect(screen.queryByText("2030–2039")).not.toBeNull();
+
+    fireEvent.click(screen.getByLabelText("datePicker.previousDecade"));
+    fireEvent.click(screen.getByLabelText("datePicker.previousDecade"));
+    expect(screen.queryByText("2010–2019")).not.toBeNull();
+  });
+
+  it("rolls the year over when stepping past December/January at day-level", () => {
+    const { container } = render(<DatePicker value="2026-01-13" onChange={jest.fn()} weekStartDay={1} />);
+    openPicker(container);
+    expect(screen.queryByText("January 2026")).not.toBeNull();
+
+    fireEvent.click(screen.getByLabelText("datePicker.previousMonth"));
+    expect(screen.queryByText("December 2025")).not.toBeNull();
+
+    fireEvent.click(screen.getByLabelText("datePicker.nextMonth"));
+    fireEvent.click(screen.getByLabelText("datePicker.nextMonth"));
+    expect(screen.queryByText("February 2026")).not.toBeNull();
+  });
+
+  it("commits a typed ISO date on blur", () => {
+    const onChange = jest.fn();
+    render(<DatePicker value="2026-07-13" onChange={onChange} weekStartDay={1} />);
+    const input = screen.getByRole("textbox");
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "2026-08-05" } });
+    fireEvent.blur(input);
+
+    expect(onChange).toHaveBeenCalledWith("2026-08-05");
+  });
+
+  it("discards an unparseable typed value instead of calling onChange", () => {
+    const onChange = jest.fn();
+    render(<DatePicker value="2026-07-13" onChange={onChange} weekStartDay={1} />);
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "not a date" } });
+    fireEvent.blur(input);
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input.value).toBe("Jul 13, 2026");
+  });
+
+  it("clears the value via the Clear footer action", () => {
+    const onChange = jest.fn();
+    const { container } = render(<DatePicker value="2026-07-13" onChange={onChange} weekStartDay={1} />);
+    openPicker(container);
+
+    fireEvent.click(screen.getByText("datePicker.clear"));
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("jumps to today's date via the Today footer action", () => {
+    const onChange = jest.fn();
+    const { container } = render(<DatePicker value="2026-07-13" onChange={onChange} weekStartDay={1} />);
+    openPicker(container);
+
+    fireEvent.click(screen.getByText("datePicker.today"));
+    expect(onChange).toHaveBeenCalledWith("2026-07-15");
+  });
+
+  it("closes the panel on outside click without committing anything", () => {
+    const onChange = jest.fn();
+    const { container } = render(<DatePicker value="2026-07-13" onChange={onChange} weekStartDay={1} />);
+    openPicker(container);
+    expect(container.querySelector(".date-picker__panel")).not.toBeNull();
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true }));
+    });
+
+    expect(container.querySelector(".date-picker__panel")).toBeNull();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/DatePicker/__tests__/dateGrid.spec.ts
+++ b/src/components/DatePicker/__tests__/dateGrid.spec.ts
@@ -1,0 +1,89 @@
+import { buildDayGrid, parseISO, parseTypedISO, toISO } from "../dateGrid";
+
+describe("toISO", () => {
+  it("formats year/month/day (0-indexed month) as yyyy-mm-dd", () => {
+    expect(toISO(2026, 6, 5)).toBe("2026-07-05");
+  });
+
+  it("zero-pads month and day", () => {
+    expect(toISO(2026, 0, 1)).toBe("2026-01-01");
+  });
+});
+
+describe("parseISO", () => {
+  it("parses a well-formed ISO date into 0-indexed parts", () => {
+    expect(parseISO("2026-07-13")).toEqual({ year: 2026, month: 6, day: 13 });
+  });
+
+  it("returns null for an empty string", () => {
+    expect(parseISO("")).toBeNull();
+  });
+});
+
+describe("parseTypedISO", () => {
+  it("accepts a well-formed yyyy-mm-dd", () => {
+    expect(parseTypedISO("2026-07-13")).toBe("2026-07-13");
+  });
+
+  it("accepts single-digit month/day and normalizes to zero-padded", () => {
+    expect(parseTypedISO("2026-7-3")).toBe("2026-07-03");
+  });
+
+  it("rejects a calendar date that doesn't exist (Feb 30)", () => {
+    expect(parseTypedISO("2026-02-30")).toBeNull();
+  });
+
+  it("rejects an out-of-range month", () => {
+    expect(parseTypedISO("2026-13-01")).toBeNull();
+  });
+
+  it("rejects garbage input", () => {
+    expect(parseTypedISO("not a date")).toBeNull();
+    expect(parseTypedISO("07/13/2026")).toBeNull();
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parseTypedISO("  2026-07-13  ")).toBe("2026-07-13");
+  });
+});
+
+describe("buildDayGrid", () => {
+  it("always returns exactly 42 cells (a 6-week grid)", () => {
+    expect(buildDayGrid(2026, 6, 1)).toHaveLength(42);
+  });
+
+  it("starts the grid on Monday when weekStartDay is 1", () => {
+    // Jul 1, 2026 is a Wednesday; with Monday as the first column, the grid
+    // should lead with Jun 29-30 (Mon, Tue) as overflow before Jul 1.
+    const cells = buildDayGrid(2026, 6, 1);
+    expect(cells[0]).toEqual({ iso: "2026-06-29", day: 29, inMonth: false });
+    expect(cells[1]).toEqual({ iso: "2026-06-30", day: 30, inMonth: false });
+    expect(cells[2]).toEqual({ iso: "2026-07-01", day: 1, inMonth: true });
+  });
+
+  it("starts the grid on Sunday when weekStartDay is 0", () => {
+    // Jul 1, 2026 (Wed) is 3 days after Sunday Jun 28.
+    const cells = buildDayGrid(2026, 6, 0);
+    expect(cells[0]).toEqual({ iso: "2026-06-28", day: 28, inMonth: false });
+    expect(cells[3]).toEqual({ iso: "2026-07-01", day: 1, inMonth: true });
+  });
+
+  it("pads the tail of the grid with the next month's overflow days", () => {
+    const cells = buildDayGrid(2026, 6, 1); // July 2026, Monday-start
+    const last = cells[cells.length - 1];
+    expect(last.inMonth).toBe(false);
+    expect(last.iso.startsWith("2026-08")).toBe(true);
+  });
+
+  it("handles a December -> January month rollover for the trailing overflow", () => {
+    const cells = buildDayGrid(2025, 11, 1); // December 2025
+    const last = cells[cells.length - 1];
+    expect(last.iso.startsWith("2026-01")).toBe(true);
+  });
+
+  it("handles a January -> December rollover for the leading overflow", () => {
+    // Jan 1, 2026 is a Thursday; with Monday-start, leading overflow comes from December 2025.
+    const cells = buildDayGrid(2026, 0, 1);
+    expect(cells[0].iso.startsWith("2025-12")).toBe(true);
+  });
+});

--- a/src/components/DatePicker/dateGrid.ts
+++ b/src/components/DatePicker/dateGrid.ts
@@ -1,0 +1,86 @@
+import { formatDateToISO8601, getDaysInMonth, getToday, parseUTCDate } from "src/utils/date";
+
+export interface DateParts {
+  year: number;
+  /** 0-indexed, matching `Date`'s own convention. */
+  month: number;
+  day: number;
+}
+
+export interface DayCell {
+  iso: string;
+  day: number;
+  /** False for the previous/next month's overflow days that pad out the grid. */
+  inMonth: boolean;
+}
+
+export function toISO(year: number, month: number, day: number): string {
+  return formatDateToISO8601(new Date(Date.UTC(year, month, day))) as string;
+}
+
+/** Lenient parse for a value this component already produced itself (see `toISO`). */
+export function parseISO(iso: string): DateParts | null {
+  if (!iso) return null;
+  const date = parseUTCDate(iso);
+  if (isNaN(date.getTime())) return null;
+  return { year: date.getUTCFullYear(), month: date.getUTCMonth(), day: date.getUTCDate() };
+}
+
+/**
+ * Strict parse for a user-typed value: only a well-formed `yyyy-mm-dd`, and
+ * only when it's a real calendar date (rejects `2026-02-30` etc. instead of
+ * letting `Date`'s own rollover silently turn it into a different date).
+ */
+export function parseTypedISO(text: string): string | null {
+  const match = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(text.trim());
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) return null;
+  return toISO(year, month - 1, day);
+}
+
+export function todayParts(): DateParts {
+  const today = getToday();
+  return { year: today.getUTCFullYear(), month: today.getUTCMonth(), day: today.getUTCDate() };
+}
+
+/**
+ * A 6-week (42-cell) day grid for `year`/`month`, padded with the
+ * previous/next month's overflow days. The leading blank count is based on
+ * `weekStartDay` (not always Sunday), so the grid's columns match whatever
+ * week-start convention the rest of the report is using.
+ */
+export function buildDayGrid(year: number, month: number, weekStartDay: number): DayCell[] {
+  const cells: DayCell[] = [];
+
+  const firstWeekday = new Date(Date.UTC(year, month, 1)).getUTCDay();
+  const leadingBlanks = (firstWeekday - weekStartDay + 7) % 7;
+  const daysThisMonth = getDaysInMonth(year, month);
+
+  const prevMonth = month === 0 ? 11 : month - 1;
+  const prevYear = month === 0 ? year - 1 : year;
+  const daysPrevMonth = getDaysInMonth(prevYear, prevMonth);
+
+  for (let i = leadingBlanks - 1; i >= 0; i--) {
+    const day = daysPrevMonth - i;
+    cells.push({ iso: toISO(prevYear, prevMonth, day), day, inMonth: false });
+  }
+  for (let day = 1; day <= daysThisMonth; day++) {
+    cells.push({ iso: toISO(year, month, day), day, inMonth: true });
+  }
+
+  const nextMonth = month === 11 ? 0 : month + 1;
+  const nextYear = month === 11 ? year + 1 : year;
+  let nextDay = 1;
+  while (cells.length < 42) {
+    cells.push({ iso: toISO(nextYear, nextMonth, nextDay), day: nextDay, inMonth: false });
+    nextDay++;
+  }
+
+  return cells;
+}

--- a/src/components/icons/CalendarIcon.tsx
+++ b/src/components/icons/CalendarIcon.tsx
@@ -1,0 +1,21 @@
+export function CalendarIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="lucide lucide-calendar"
+    >
+      <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
+      <line x1="16" x2="16" y1="2" y2="6" />
+      <line x1="8" x2="8" y1="2" y2="6" />
+      <line x1="3" x2="21" y1="10" y2="10" />
+    </svg>
+  );
+}

--- a/src/components/icons/ChevronLeftIcon.tsx
+++ b/src/components/icons/ChevronLeftIcon.tsx
@@ -1,0 +1,18 @@
+export function ChevronLeftIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="lucide lucide-chevron-left"
+    >
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  );
+}

--- a/src/components/icons/ChevronRightIcon.tsx
+++ b/src/components/icons/ChevronRightIcon.tsx
@@ -1,0 +1,18 @@
+export function ChevronRightIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="lucide lucide-chevron-right"
+    >
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  );
+}

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -83,6 +83,17 @@
     "export": "Export"
   },
   "tab": "Tab",
+  "datePicker": {
+    "clear": "Clear",
+    "today": "Today",
+    "openCalendar": "Open calendar",
+    "previousMonth": "Previous month",
+    "nextMonth": "Next month",
+    "previousYear": "Previous year",
+    "nextYear": "Next year",
+    "previousDecade": "Previous decade",
+    "nextDecade": "Next decade"
+  },
   "report": {
     "defaultTitle": "Work Log Report",
     "startDate": "Start date",

--- a/src/modals/LegendModal.ts
+++ b/src/modals/LegendModal.ts
@@ -1,36 +1,278 @@
 import { App, Modal, Setting, setIcon } from "obsidian";
 import { EMPTY_CELL_COLOR } from "../utils/report/heatmapHtml";
-import { LegendEntry } from "../utils/report/legend";
+import { LegendEntry, LegendVisibility, getLegendVisibility, nextLegendVisibility, setLegendVisibility } from "../utils/report/legend";
+import { normalizeColor } from "../utils/report/legendMatch";
 
 function isBlankColor(color: string): boolean {
   return color.trim().toLowerCase() === EMPTY_CELL_COLOR.trim().toLowerCase();
 }
 
+const VISIBILITY_ICON: Record<LegendVisibility, string> = {
+  shown: "eye",
+  summaryHidden: "eye-off",
+  hidden: "eye-closed",
+};
+
+const VISIBILITY_TITLE: Record<LegendVisibility, string> = {
+  shown: "Shown in legend and summary - click to hide from summary",
+  summaryHidden: "Shown in legend only, not summary - click to hide entirely",
+  hidden: "Hidden entirely - click to show again",
+};
+
+/** The shared visibility if every entry agrees, otherwise "shown" as a neutral starting point for the next click. */
+export function aggregateVisibility(entries: LegendEntry[]): LegendVisibility {
+  const visibilities = entries.map(getLegendVisibility);
+  const first = visibilities[0] ?? "shown";
+  return visibilities.every((v) => v === first) ? first : "shown";
+}
+
+export type LegendDisplayMode = "separate" | "gradient";
+
 /**
- * Popup editor for the report's {color, label} legend. The same list drives
- * both the legend rendered under the heatmap and the summary's day-type
- * breakdown (see src/utils/report/legend.ts). Rows can be dragged to reorder
- * (controls the order categories appear in the summary line) and toggled to
- * exclude a category from the summary line entirely (its days still count
- * correctly toward `Other`/matching — see `buildSummaryParts`).
+ * Merges `entries` with a default baseline, preserving `entries`' own
+ * customizations *and* relative order — only appending brand-new colors (in
+ * the baseline's own order) and dropping any entry whose color doesn't
+ * appear in the baseline at all. This is the "Refresh" button's whole job:
+ * fetch new colors and remove genuinely stale ones without disturbing
+ * anything the user has already set up. Called with `LegendModal`'s own
+ * `baseline` — every color used ANYWHERE in the whole calendar, not just the
+ * export's current date range (see `ExportView.buildRefreshBaseline`) — so a
+ * color only drops out here once it no longer appears at all, not merely
+ * because the currently selected range doesn't happen to include it.
+ */
+export function mergeLegendWithDefaults(entries: LegendEntry[], defaults: LegendEntry[]): LegendEntry[] {
+  const isInDefaults = (color: string) => defaults.some((d) => normalizeColor(d.color) === normalizeColor(color));
+  const kept = entries.filter((entry) => isInDefaults(entry.color));
+  const keptColors = new Set(kept.map((entry) => normalizeColor(entry.color)));
+  const added = defaults.filter((d) => !keptColors.has(normalizeColor(d.color)));
+  return [...kept, ...added];
+}
+
+/**
+ * `entries` whose color is actually in `colorsList` (the configured
+ * intensity palette), in the palette's own low-to-high order — not
+ * `entries`' own order, which may have been drag-reordered for separate-mode
+ * display and has no bearing on the gradient strip's fixed intensity
+ * ordering. This is exactly the set of colors gradient mode squashes into
+ * one row (see `LegendModal.renderGradientGroupRow`); any entry whose color
+ * isn't in `colorsList` at all (a custom color used on individual days, or
+ * the blank/background color) is never included here and keeps its own full
+ * row instead.
+ */
+export function paletteEntriesInOrder(entries: LegendEntry[], colorsList: string[]): LegendEntry[] {
+  return colorsList
+    .map((color) => entries.find((entry) => normalizeColor(entry.color) === normalizeColor(color)))
+    .filter((entry): entry is LegendEntry => entry !== undefined);
+}
+
+/**
+ * Moves `dragged` (one entry for a normal row, or every palette-color entry
+ * at once for the gradient group row) to sit immediately before the first
+ * entry of `target` that isn't itself part of `dragged` — matching the
+ * drop-target highlight's own documented behavior ("dropping lands the
+ * dragged row(s) just before this one"). A no-op (returns `entries`
+ * unchanged) when `dragged` and `target` overlap at all (dropped on itself).
+ * Works by entry identity, not index, so it applies equally whether one row
+ * or an entire contiguous block is moving.
+ */
+export function reorderLegendEntries(
+  entries: LegendEntry[],
+  dragged: LegendEntry[],
+  target: LegendEntry[],
+): LegendEntry[] {
+  const draggedSet = new Set(dragged);
+  if (target.some((entry) => draggedSet.has(entry))) return entries;
+
+  const rest = entries.filter((entry) => !draggedSet.has(entry));
+  const anchor = target.find((entry) => rest.includes(entry));
+  const insertIndex = anchor ? rest.indexOf(anchor) : rest.length;
+
+  return [...rest.slice(0, insertIndex), ...dragged, ...rest.slice(insertIndex)];
+}
+
+/**
+ * Popup opened from the gear icon on the gradient-mode squashed row (see
+ * `LegendModal.renderGradientGroupRow`) — the squashed row only has room for
+ * one shared label, not one control per palette color, so per-color day-
+ * count weight and fixed value are set here instead. No separate
+ * include/exclude toggle: a weight of 0 already excludes a color from the
+ * shared total, so a second control for the same thing would be redundant
+ * (bulk-toggling every palette color at once is still available via the
+ * group eye button on the squashed row itself). Mutates the given entries in
+ * place (the very same objects referenced by the parent modal's `entries`
+ * array), so there's nothing to save back explicitly — closing this popup is
+ * enough.
+ */
+class GradientWeightsModal extends Modal {
+  private listEl: HTMLElement | null = null;
+
+  constructor(
+    app: App,
+    private entries: LegendEntry[],
+  ) {
+    super(app);
+  }
+
+  onOpen() {
+    const { contentEl } = this;
+    contentEl.empty();
+    this.modalEl.addClass("heatmap-legend-modal");
+    this.setTitle("Palette color settings");
+
+    contentEl.createEl("p", {
+      cls: "heatmap-legend-modal__hint heatmap-legend-modal__hint--italic",
+      text: "For each color in the palette, you can optionally set a fixed value per day and specify how much it's weighted towards the shared day count.",
+    });
+
+    this.listEl = contentEl.createDiv({ cls: "heatmap-legend-modal__list" });
+    this.renderRows();
+
+    new Setting(contentEl).addButton((btn) => btn.setButtonText("Done").setCta().onClick(() => this.close()));
+  }
+
+  onClose() {
+    this.contentEl.empty();
+  }
+
+  private renderRows() {
+    const container = this.listEl;
+    if (!container) return;
+    container.empty();
+
+    this.entries.forEach((entry) => {
+      const row = container.createDiv({ cls: "heatmap-legend-modal__row" });
+      const visibility = getLegendVisibility(entry);
+      row.toggleClass("is-excluded", visibility === "summaryHidden");
+      row.toggleClass("is-hidden", visibility === "hidden");
+
+      const swatch = row.createDiv({ cls: "heatmap-legend-modal__swatch" });
+      swatch.style.backgroundColor = entry.color;
+
+      row.createSpan({ cls: "heatmap-legend-modal__color-text", text: entry.color });
+
+      const valueOverrideInput = row.createEl("input", {
+        cls: "heatmap-legend-modal__value-input",
+        attr: {
+          type: "number",
+          step: "any",
+          placeholder: "value",
+          "aria-label": "Fixed value for this color, overriding its actual logged value",
+        },
+        value: entry.valueOverride !== undefined ? String(entry.valueOverride) : "",
+      });
+      valueOverrideInput.addEventListener("input", () => {
+        const trimmed = valueOverrideInput.value.trim();
+        const parsed = Number(trimmed);
+        entry.valueOverride = trimmed === "" || Number.isNaN(parsed) ? undefined : parsed;
+      });
+
+      const weightInput = row.createEl("input", {
+        cls: "heatmap-legend-modal__weight-input",
+        attr: {
+          type: "number",
+          step: "any",
+          min: "0",
+          placeholder: "weight",
+          "aria-label": "Day-count weight (e.g. 0.5 for a half day, or 0 to exclude entirely)",
+        },
+        value: entry.countWeight !== undefined ? String(entry.countWeight) : "",
+      });
+      weightInput.addEventListener("input", () => {
+        const trimmed = weightInput.value.trim();
+        const parsed = Number(trimmed);
+        entry.countWeight = trimmed === "" || Number.isNaN(parsed) ? undefined : parsed;
+      });
+    });
+  }
+}
+
+/**
+ * Popup editor for the report's {color, label} legend. Rows are auto-
+ * populated (one per configured intensity color, plus the blank/background
+ * color) by the caller — see `ExportView`'s default-entries builder — since
+ * every color the calendar can ever show is already known in advance; there
+ * is deliberately no way to add an arbitrary extra row or delete one here,
+ * only to customize the ones that exist. That population only happens
+ * up front though — reopening this modal shows exactly what was last saved,
+ * untouched, unless the user explicitly clicks "Refresh" (merge in any new
+ * colors, drop any stale ones, keep everything else exactly as edited/
+ * reordered — see `mergeLegendWithDefaults`) or "Reset" (discard all
+ * customizations and start over from scratch). Both draw from the exact same
+ * `baseline` — every color used ANYWHERE in the whole calendar, not just the
+ * export's current date range (see `ExportView.buildRefreshBaseline`) — so
+ * neither one silently drops a color just because none of its days happen to
+ * fall within whatever range is currently selected.
+ *
+ * The same list drives both the legend rendered under the heatmap and the
+ * summary's day-type breakdown (see `src/utils/report/legend.ts`). Rows can
+ * be dragged (via the grip handle specifically, not the row at large) to
+ * reorder — controls the order categories appear in separate-rows mode.
+ * Colors themselves aren't editable here — they're sourced automatically
+ * from the calendar's actual palette, so retyping one would just desync the
+ * swatch from what the calendar really shows; shown as plain text next to
+ * the swatch rather than a (disabled-looking) input.
+ *
+ * Each row's borderless eye button (unboxed, matching `GradientWeightsModal`)
+ * cycles through three visibility states (see `LegendVisibility`): shown in
+ * both the legend and the summary; shown in the legend only; hidden from
+ * both. Its days still count correctly toward `Other`/matching either way
+ * (see `buildSummaryModel`) — only its own display is affected.
+ *
+ * The legend-style dropdown switches between "separate" (one row per color,
+ * each with its own label) and "gradient". In gradient mode, every row whose
+ * color is actually in the configured intensity palette (`colorsList`) is
+ * squashed into a single row: a mini GitHub-style swatch strip on the left
+ * (see `renderGradientGroupRow`) instead of one swatch per color, a shared-
+ * label input, a gear icon opening `GradientWeightsModal` to set each
+ * palette color's day-count weight/fixed value, and a group eye button that
+ * bulk-applies a visibility state to every palette color at once. This row
+ * is draggable too, just like any other — dragging it moves every palette
+ * color together as one contiguous block (see `reorderLegendEntries`),
+ * without disturbing their relative order among themselves. Individual
+ * palette colors' own labels are left untouched in memory while squashed —
+ * they simply aren't shown — and reappear as soon as the user switches back
+ * to "separate" mode. Any matched color outside the palette (including the
+ * blank/background color) is never squashed — it always keeps its own full,
+ * independent, draggable row in both modes.
  */
 export class LegendModal extends Modal {
   private entries: LegendEntry[];
-  private detectedColors: string[];
-  private onSave: (entries: LegendEntry[]) => void;
+  private baseline: LegendEntry[];
+  private colorsList: string[];
+  private legendMode: LegendDisplayMode;
+  private gradientLabel: string;
+  private onSave: (entries: LegendEntry[], legendMode: LegendDisplayMode, gradientLabel: string) => void;
   private listEl: HTMLElement | null = null;
-  private dragFromIndex: number | null = null;
+  /** The entries currently being dragged - a single entry for a normal row, or every palette-color entry at once for the gradient group row. */
+  private dragPayload: LegendEntry[] | null = null;
 
   constructor(
     app: App,
     initialEntries: LegendEntry[],
-    detectedColors: string[],
-    onSave: (entries: LegendEntry[]) => void,
+    baseline: LegendEntry[],
+    colorsList: string[],
+    initialLegendMode: LegendDisplayMode,
+    initialGradientLabel: string,
+    onSave: (entries: LegendEntry[], legendMode: LegendDisplayMode, gradientLabel: string) => void,
   ) {
     super(app);
     this.entries = initialEntries.map((entry) => ({ ...entry }));
-    this.detectedColors = detectedColors;
+    // Every color used ANYWHERE in the whole calendar, not just within the
+    // export's currently selected date range (see
+    // `ExportView.buildRefreshBaseline`) - shared by "Refresh" (merge it in,
+    // keeping existing customizations) and "Reset" (discard everything and
+    // clone it fresh), so neither one shows a narrower set of colors than
+    // the other depending on which is clicked.
+    this.baseline = baseline;
+    this.colorsList = colorsList;
+    this.legendMode = initialLegendMode;
+    this.gradientLabel = initialGradientLabel;
     this.onSave = onSave;
+  }
+
+  /** Normalized set of the configured intensity palette's own colors. */
+  private paletteColorSet(): Set<string> {
+    return new Set(this.colorsList.map(normalizeColor));
   }
 
   onOpen() {
@@ -48,26 +290,44 @@ export class LegendModal extends Modal {
     this.renderRows();
 
     const footnote = contentEl.createEl("p", { cls: "heatmap-legend-modal__footnote" });
-    footnote.appendText("Drag rows to reorder. Hide a category to exclude it from the summary.");
+    footnote.appendText(
+      "Drag rows to reorder. Click the eye to cycle through shown, summary-hidden, and fully hidden.",
+    );
     footnote.createEl("br");
     footnote.appendText("Optionally set fixed values to make every day in that category use the same value.");
 
     const buttonRow = contentEl.createDiv({ cls: "heatmap-legend-modal__button-row" });
 
-    const addBtn = buttonRow.createEl("button", {
-      cls: "mod-cta",
-      text: "Add row",
+    // "dropdown" is Obsidian's own class for select elements (applied
+    // automatically by its DropdownComponent elsewhere) - without it, a bare
+    // <select> picks up the same border/background/height as a <button> and
+    // reads as one more button in the row instead of a distinct dropdown.
+    const modeSelect = buttonRow.createEl("select", { cls: "heatmap-legend-modal__mode-select dropdown" });
+    modeSelect.createEl("option", { value: "separate", text: "Separate rows" });
+    modeSelect.createEl("option", { value: "gradient", text: "Single gradient row" });
+    modeSelect.value = this.legendMode;
+
+    modeSelect.addEventListener("change", () => {
+      this.legendMode = modeSelect.value as LegendDisplayMode;
+      this.renderRows();
     });
-    addBtn.addEventListener("click", () => {
-      this.entries.push({ color: "#7bc96f", label: "" });
+
+    const refreshBtn = buttonRow.createEl("button", {
+      attr: { "aria-label": "Fetch new colors and drop stale ones, keeping everything else as-is" },
+      text: "Refresh colors",
+    });
+    refreshBtn.addEventListener("click", () => {
+      this.entries = mergeLegendWithDefaults(this.entries, this.baseline);
       this.renderRows();
     });
 
     const resetBtn = buttonRow.createEl("button", {
+      cls: "mod-warning",
+      attr: { "aria-label": "Discard all customizations and start over" },
       text: "Reset",
     });
     resetBtn.addEventListener("click", () => {
-      this.entries = this.detectedColors.map((color) => ({ color, label: "" }));
+      this.entries = this.baseline.map((entry) => ({ ...entry }));
       this.renderRows();
     });
 
@@ -76,7 +336,10 @@ export class LegendModal extends Modal {
         .setButtonText("Done")
         .setCta()
         .onClick(() => {
-          this.onSave(this.entries.filter((entry) => entry.label.trim() !== ""));
+          // Every row is already a real, meaningful color slot (auto-
+          // populated by the caller) - there's no "untouched Add row" junk
+          // to filter out anymore, so entries are saved exactly as edited.
+          this.onSave(this.entries, this.legendMode, this.gradientLabel);
           this.close();
         }),
     );
@@ -96,54 +359,188 @@ export class LegendModal extends Modal {
         cls: "heatmap-legend-modal__empty",
         text: "No legend entries yet.",
       });
+      return;
     }
 
-    this.entries.forEach((entry, index) => {
-      const row = container.createDiv({ cls: "heatmap-legend-modal__row" });
-      row.toggleClass("is-excluded", entry.includeInSummary === false);
-      row.setAttribute("draggable", "true");
+    if (this.legendMode !== "gradient") {
+      this.entries.forEach((entry) => this.renderEntryRow(container, entry));
+      return;
+    }
 
-      row.addEventListener("dragstart", (evt) => {
-        this.dragFromIndex = index;
-        row.addClass("is-dragging");
-        evt.dataTransfer?.setData("text/plain", String(index));
-      });
-      row.addEventListener("dragend", () => {
-        this.dragFromIndex = null;
-        row.removeClass("is-dragging");
-      });
-      row.addEventListener("dragover", (evt) => {
+    // The group row renders wherever the palette-color block currently sits
+    // in `this.entries` (at the position of the first palette-color entry
+    // encountered) rather than always first - that's what makes it draggable
+    // to a genuinely different position, not just visually fixed up front.
+    const paletteColors = this.paletteColorSet();
+    const paletteBlock = this.entries.filter((entry) => paletteColors.has(normalizeColor(entry.color)));
+    let groupRendered = false;
+
+    this.entries.forEach((entry) => {
+      if (paletteColors.has(normalizeColor(entry.color))) {
+        if (!groupRendered) {
+          this.renderGradientGroupRow(container, paletteBlock);
+          groupRendered = true;
+        }
+        return;
+      }
+      this.renderEntryRow(container, entry);
+    });
+  }
+
+  /**
+   * Wires up drag-to-reorder for `row`, whose "identity" for reordering
+   * purposes is `payload` (one entry for a normal row; every palette-color
+   * entry at once for the gradient group row - see `reorderLegendEntries`).
+   * Returns an `arm()` callback to wire to the row's own grip handle's
+   * `mousedown` - a drag is only actually allowed to start if the initiating
+   * mousedown was on that handle, so clicking/selecting text in the label or
+   * number inputs elsewhere in the row can't accidentally start reordering.
+   */
+  private wireDraggable(row: HTMLElement, payload: LegendEntry[]): () => void {
+    row.setAttribute("draggable", "true");
+    let dragArmed = false;
+
+    row.addEventListener("dragstart", (evt) => {
+      if (!dragArmed) {
         evt.preventDefault();
-      });
-      row.addEventListener("drop", (evt) => {
-        evt.preventDefault();
-        const fromIndex = this.dragFromIndex;
-        if (fromIndex === null || fromIndex === index) return;
-        const [moved] = this.entries.splice(fromIndex, 1);
-        this.entries.splice(index, 0, moved);
-        this.renderRows();
-      });
+        return;
+      }
+      this.dragPayload = payload;
+      row.addClass("is-dragging");
+      evt.dataTransfer?.setData("text/plain", "1");
+      if (evt.dataTransfer) evt.dataTransfer.effectAllowed = "move";
+    });
+    row.addEventListener("dragend", () => {
+      dragArmed = false;
+      this.dragPayload = null;
+      row.removeClass("is-dragging");
+    });
+    row.addEventListener("dragenter", (evt) => {
+      if (!this.dragPayload || this.dragPayload === payload) return;
+      evt.preventDefault();
+      row.addClass("is-drag-over");
+    });
+    row.addEventListener("dragleave", (evt) => {
+      // dragenter/dragleave fire on every nested-element boundary crossing
+      // within the row too, not just when actually leaving it - only clear
+      // the drop-target highlight once the pointer has genuinely left.
+      const related = evt.relatedTarget as Node | null;
+      if (related && row.contains(related)) return;
+      row.removeClass("is-drag-over");
+    });
+    row.addEventListener("dragover", (evt) => {
+      evt.preventDefault();
+      if (evt.dataTransfer) evt.dataTransfer.dropEffect = "move";
+    });
+    row.addEventListener("drop", (evt) => {
+      evt.preventDefault();
+      row.removeClass("is-drag-over");
+      this.handleDrop(payload);
+    });
+
+    return () => {
+      dragArmed = true;
+    };
+  }
+
+  private handleDrop(targetPayload: LegendEntry[]) {
+    if (!this.dragPayload) return;
+    this.entries = reorderLegendEntries(this.entries, this.dragPayload, targetPayload);
+    this.dragPayload = null;
+    this.renderRows();
+  }
+
+  /**
+   * The gradient-mode-only squashed row standing in for every palette-color
+   * entry at once: a mini swatch strip (no HEX — it's several colors, not
+   * one) instead of the usual single swatch, the shared label input, a gear
+   * icon opening `GradientWeightsModal` for per-color weight/value, and a
+   * group eye button that bulk-applies to every palette color at once.
+   * Draggable via its own handle just like any other row - dropping it moves
+   * `paletteBlock` (every palette-color entry, in `this.entries`' own current
+   * relative order - not recomputed to intensity order) as one contiguous
+   * block (see `reorderLegendEntries`). The swatch strip itself, and the
+   * weights popup's own ordering, still always follow the palette's true
+   * low-to-high intensity order (`paletteEntriesInOrder`) regardless of
+   * where `paletteBlock` currently sits or how its members are internally
+   * ordered - that's a display/data-entry concern, unrelated to this row's
+   * position among the others.
+   */
+  private renderGradientGroupRow(container: HTMLElement, paletteBlock: LegendEntry[]) {
+    const intensityOrder = paletteEntriesInOrder(this.entries, this.colorsList);
+    const groupVisibility = aggregateVisibility(intensityOrder);
+
+    const row = container.createDiv({ cls: "heatmap-legend-modal__row" });
+    row.toggleClass("is-excluded", groupVisibility === "summaryHidden");
+    row.toggleClass("is-hidden", groupVisibility === "hidden");
+    const arm = this.wireDraggable(row, paletteBlock);
+
+    const handle = row.createDiv({ cls: "heatmap-legend-modal__handle" });
+    setIcon(handle, "grip-vertical");
+    handle.addEventListener("mousedown", arm);
+
+    const strip = row.createDiv({ cls: "heatmap-legend-modal__gradient-strip" });
+    intensityOrder.forEach((entry) => {
+      const swatch = strip.createDiv({ cls: "heatmap-legend-modal__gradient-strip-swatch" });
+      swatch.style.backgroundColor = entry.color;
+    });
+
+    const labelInput = row.createEl("input", {
+      cls: "heatmap-legend-modal__label-input",
+      attr: { type: "text", placeholder: "Shared label (e.g. Activity)" },
+      value: this.gradientLabel,
+    });
+    labelInput.addEventListener("input", () => {
+      this.gradientLabel = labelInput.value;
+    });
+
+    const gearBtn = row.createEl("button", {
+      cls: "heatmap-legend-modal__gear-button clickable-icon",
+      attr: { "aria-label": "Set each palette color's day-count weight and fixed value" },
+    });
+    setIcon(gearBtn, "settings");
+    gearBtn.addEventListener("click", () => {
+      new GradientWeightsModal(this.app, intensityOrder).open();
+    });
+
+    // Bulk-applies to every palette color at once - the gear icon above
+    // still lets each color's weight/value be set independently.
+    const groupIncludeToggle = row.createEl("button", {
+      cls: "heatmap-legend-modal__include-toggle clickable-icon",
+      attr: {
+        "aria-label": `${VISIBILITY_TITLE[groupVisibility]} (applies to every palette color)`,
+      },
+    });
+    setIcon(groupIncludeToggle, VISIBILITY_ICON[groupVisibility]);
+    groupIncludeToggle.addEventListener("click", () => {
+      const next = nextLegendVisibility(groupVisibility);
+      intensityOrder.forEach((entry) => setLegendVisibility(entry, next));
+      this.renderRows();
+    });
+  }
+
+  private renderEntryRow(container: HTMLElement, entry: LegendEntry) {
+    const row = container.createDiv({ cls: "heatmap-legend-modal__row" });
+      const visibility = getLegendVisibility(entry);
+      row.toggleClass("is-excluded", visibility === "summaryHidden");
+      row.toggleClass("is-hidden", visibility === "hidden");
+      const arm = this.wireDraggable(row, [entry]);
 
       const handle = row.createDiv({ cls: "heatmap-legend-modal__handle" });
       setIcon(handle, "grip-vertical");
+      handle.addEventListener("mousedown", arm);
 
       const swatch = row.createDiv({ cls: "heatmap-legend-modal__swatch" });
       swatch.style.backgroundColor = entry.color;
 
+      // Colors are sourced automatically from the calendar's real palette
+      // (see the class doc comment) - never editable, so shown as plain text
+      // next to the swatch rather than a (disabled-looking) input box.
       const blank = isBlankColor(entry.color);
-      const colorInput = row.createEl("input", {
-        cls: "heatmap-legend-modal__color-input",
-        attr: { type: "text", placeholder: "#7bc96f" },
-        value: blank ? "Blank" : entry.color,
+      row.createSpan({
+        cls: "heatmap-legend-modal__color-text",
+        text: blank ? "Blank" : entry.color,
       });
-      if (blank) {
-        colorInput.disabled = true;
-      } else {
-        colorInput.addEventListener("input", () => {
-          entry.color = colorInput.value;
-          swatch.style.backgroundColor = colorInput.value;
-        });
-      }
 
       const labelInput = row.createEl("input", {
         cls: "heatmap-legend-modal__label-input",
@@ -160,7 +557,6 @@ export class LegendModal extends Modal {
           type: "number",
           step: "any",
           placeholder: "value",
-          title: "To set fixed value (overriding actual values)",
           "aria-label": "To set fixed value (overriding actual values)",
         },
         value: entry.valueOverride !== undefined ? String(entry.valueOverride) : "",
@@ -171,30 +567,20 @@ export class LegendModal extends Modal {
         entry.valueOverride = trimmed === "" || Number.isNaN(parsed) ? undefined : parsed;
       });
 
-      const included = entry.includeInSummary !== false;
-      const includeToggleLabel = included ? "Click to exclude from summary" : "Click to include in summary";
-      const includeToggle = row.createEl("button", {
-        cls: "heatmap-legend-modal__include-toggle",
-        attr: {
-          title: includeToggleLabel,
-          "aria-label": includeToggleLabel,
-        },
-      });
-      setIcon(includeToggle, included ? "eye" : "eye-off");
-      includeToggle.addEventListener("click", () => {
-        entry.includeInSummary = included ? false : true;
-        this.renderRows();
-      });
+      // Day-count weight only ever applies to palette colors being combined
+      // in gradient mode - this row is only ever rendered for a color that
+      // ISN'T in the palette (palette colors are squashed into the gradient
+      // group row instead - see `renderGradientGroupRow`/`GradientWeightsModal`),
+      // so there's nothing to weight here.
 
-      const removeBtn = row.createEl("button", {
-        cls: "heatmap-legend-modal__remove-button",
-        attr: { "aria-label": "Remove row" },
+      const includeToggle = row.createEl("button", {
+        cls: "heatmap-legend-modal__include-toggle clickable-icon",
+        attr: { "aria-label": VISIBILITY_TITLE[visibility] },
       });
-      setIcon(removeBtn, "x");
-      removeBtn.addEventListener("click", () => {
-        this.entries.splice(index, 1);
+      setIcon(includeToggle, VISIBILITY_ICON[visibility]);
+      includeToggle.addEventListener("click", () => {
+        setLegendVisibility(entry, nextLegendVisibility(visibility));
         this.renderRows();
       });
-    });
   }
 }

--- a/src/modals/__tests__/LegendModal.test.ts
+++ b/src/modals/__tests__/LegendModal.test.ts
@@ -1,0 +1,186 @@
+import { LegendEntry } from "src/utils/report/legend";
+import { EMPTY_CELL_COLOR } from "src/utils/report/heatmapHtml";
+import {
+  aggregateVisibility,
+  mergeLegendWithDefaults,
+  paletteEntriesInOrder,
+  reorderLegendEntries,
+} from "../LegendModal";
+
+describe("mergeLegendWithDefaults", () => {
+  const defaults: LegendEntry[] = [
+    { color: "#c6e48b", label: "", includeInSummary: false },
+    { color: "#7bc96f", label: "" },
+    { color: EMPTY_CELL_COLOR, label: "", includeInSummary: false },
+  ];
+
+  it("preserves an existing entry's customizations for a color still in defaults", () => {
+    const entries: LegendEntry[] = [{ color: "#7bc96f", label: "Workday", valueOverride: 8 }];
+    const merged = mergeLegendWithDefaults(entries, defaults);
+
+    expect(merged.find((e) => e.color === "#7bc96f")).toEqual({
+      color: "#7bc96f",
+      label: "Workday",
+      valueOverride: 8,
+    });
+  });
+
+  it("appends the fresh default for a color not yet present, without touching existing entries", () => {
+    const entries: LegendEntry[] = [{ color: "#7bc96f", label: "Workday" }];
+    const merged = mergeLegendWithDefaults(entries, defaults);
+
+    expect(merged.find((e) => e.color === "#c6e48b")).toEqual(defaults[0]);
+    expect(merged.find((e) => e.color === "#7bc96f")).toEqual({ color: "#7bc96f", label: "Workday" });
+  });
+
+  it("drops an entry whose color no longer appears in the current defaults", () => {
+    const entries: LegendEntry[] = [
+      { color: "#7bc96f", label: "Workday" },
+      { color: "#orphaned-color", label: "Stale" },
+    ];
+    const merged = mergeLegendWithDefaults(entries, defaults);
+
+    expect(merged.some((e) => e.color === "#orphaned-color")).toBe(false);
+    expect(merged).toHaveLength(defaults.length);
+  });
+
+  it("preserves the existing entries' own relative order instead of resetting to the defaults' order", () => {
+    // The user drag-reordered so blank comes first - refreshing must not
+    // silently reshuffle that back to palette order.
+    const entries: LegendEntry[] = [
+      { color: EMPTY_CELL_COLOR, label: "Rest day" },
+      { color: "#7bc96f", label: "Workday" },
+    ];
+    const merged = mergeLegendWithDefaults(entries, defaults);
+
+    expect(merged.map((e) => e.color)).toEqual([EMPTY_CELL_COLOR, "#7bc96f", "#c6e48b"]);
+  });
+
+  it("appends brand-new colors in the defaults' own order, after all preserved entries", () => {
+    const entries: LegendEntry[] = [{ color: EMPTY_CELL_COLOR, label: "Rest day" }];
+    const biggerDefaults: LegendEntry[] = [
+      { color: "#c6e48b", label: "" },
+      { color: "#7bc96f", label: "" },
+      { color: "#196127", label: "" },
+      { color: EMPTY_CELL_COLOR, label: "" },
+    ];
+    const merged = mergeLegendWithDefaults(entries, biggerDefaults);
+
+    expect(merged.map((e) => e.color)).toEqual([EMPTY_CELL_COLOR, "#c6e48b", "#7bc96f", "#196127"]);
+  });
+
+  it("is a no-op when nothing has changed (idempotent)", () => {
+    const entries: LegendEntry[] = [
+      { color: "#7bc96f", label: "Workday" },
+      { color: "#c6e48b", label: "Half day", includeInSummary: false },
+      { color: EMPTY_CELL_COLOR, label: "Rest day" },
+    ];
+    expect(mergeLegendWithDefaults(entries, defaults)).toEqual(entries);
+  });
+
+  it("returns exactly the defaults, in order, when starting from empty (first-time population)", () => {
+    expect(mergeLegendWithDefaults([], defaults)).toEqual(defaults);
+  });
+});
+
+describe("paletteEntriesInOrder", () => {
+  const colorsList = ["#c6e48b", "#7bc96f", "#196127"];
+
+  it("returns entries matching a palette color, in the palette's own order, ignoring the entries' own order", () => {
+    const entries: LegendEntry[] = [
+      { color: "#196127", label: "Dark" },
+      { color: "#c6e48b", label: "Light" },
+      { color: "#7bc96f", label: "Medium" },
+    ];
+
+    expect(paletteEntriesInOrder(entries, colorsList).map((e) => e.color)).toEqual([
+      "#c6e48b",
+      "#7bc96f",
+      "#196127",
+    ]);
+  });
+
+  it("excludes a matched color that isn't in the palette (e.g. a custom per-day color, or blank)", () => {
+    const entries: LegendEntry[] = [
+      { color: "#c6e48b", label: "Light" },
+      { color: "#f59e0b", label: "Rest day work" },
+      { color: EMPTY_CELL_COLOR, label: "" },
+    ];
+
+    expect(paletteEntriesInOrder(entries, colorsList).map((e) => e.color)).toEqual(["#c6e48b"]);
+  });
+
+  it("skips a palette color with no matching entry, rather than inserting a placeholder", () => {
+    const entries: LegendEntry[] = [{ color: "#c6e48b", label: "Light" }];
+
+    expect(paletteEntriesInOrder(entries, colorsList).map((e) => e.color)).toEqual(["#c6e48b"]);
+  });
+
+  it("returns an empty array when nothing matches the palette", () => {
+    expect(paletteEntriesInOrder([{ color: "#f59e0b", label: "Rest day work" }], colorsList)).toEqual([]);
+  });
+});
+
+describe("aggregateVisibility", () => {
+  it("returns the shared visibility when every entry agrees", () => {
+    const entries: LegendEntry[] = [
+      { color: "#c6e48b", label: "", includeInSummary: false },
+      { color: "#7bc96f", label: "", includeInSummary: false },
+    ];
+    expect(aggregateVisibility(entries)).toBe("summaryHidden");
+  });
+
+  it("defaults to 'shown' when entries disagree, as a neutral starting point", () => {
+    const entries: LegendEntry[] = [
+      { color: "#c6e48b", label: "" },
+      { color: "#7bc96f", label: "", includeInSummary: false },
+    ];
+    expect(aggregateVisibility(entries)).toBe("shown");
+  });
+
+  it("returns 'shown' for an empty list", () => {
+    expect(aggregateVisibility([])).toBe("shown");
+  });
+});
+
+describe("reorderLegendEntries", () => {
+  const workday: LegendEntry = { color: "#196127", label: "Workday" };
+  const leave: LegendEntry = { color: "#8b95a5", label: "Leave" };
+  const restWork: LegendEntry = { color: "#f59e0b", label: "Rest day work" };
+  const blank: LegendEntry = { color: EMPTY_CELL_COLOR, label: "" };
+
+  it("moves a single dragged entry to sit immediately before the target", () => {
+    const entries = [workday, leave, restWork, blank];
+    const reordered = reorderLegendEntries(entries, [blank], [leave]);
+
+    expect(reordered).toEqual([workday, blank, leave, restWork]);
+  });
+
+  it("moves an entire block together, preserving the block's own internal order", () => {
+    // Simulates dragging the gradient group row (a multi-entry block) to sit
+    // before an independent entry - block members are workday/blank, in
+    // this.entries' own relative order, not recomputed to any other order.
+    const entries = [leave, workday, blank, restWork];
+    const block = [workday, blank];
+    const reordered = reorderLegendEntries(entries, block, [leave]);
+
+    expect(reordered).toEqual([workday, blank, leave, restWork]);
+  });
+
+  it("is a no-op when the dragged entry is dropped onto itself", () => {
+    const entries = [workday, leave, restWork];
+    expect(reorderLegendEntries(entries, [leave], [leave])).toBe(entries);
+  });
+
+  it("is a no-op when the drop target overlaps the dragged block at all", () => {
+    const entries = [workday, leave, restWork, blank];
+    const block = [workday, leave];
+    expect(reorderLegendEntries(entries, block, [leave, restWork])).toBe(entries);
+  });
+
+  it("appends at the end when the target isn't found in the remaining entries", () => {
+    const entries = [workday, leave];
+    const strayTarget: LegendEntry = { color: "#000000", label: "Not present" };
+    expect(reorderLegendEntries(entries, [workday], [strayTarget])).toEqual([leave, workday]);
+  });
+});

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -13,6 +13,7 @@
 @use './styles/heatmap-monthly.scss';
 @use './styles/heatmap-create-modal.scss';
 @use './styles/heatmap-export.scss';
+@use './styles/date-picker.scss';
 
 .heatmap-tracker__container,
 .heatmap-tracker-legend,

--- a/src/styles/date-picker.scss
+++ b/src/styles/date-picker.scss
@@ -1,0 +1,202 @@
+.date-picker {
+  position: relative;
+  display: inline-block;
+
+  &__trigger {
+    display: flex;
+    align-items: center;
+    gap: 0.25em;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s);
+    background: var(--background-primary);
+    padding: 0 0.4em;
+
+    &:focus-within {
+      border-color: var(--interactive-accent);
+    }
+  }
+
+  &__input {
+    border: none !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    padding: 0.25em 0 !important;
+    width: 96px;
+  }
+
+  // The calendar icon should read as part of the input box it sits in, not
+  // as its own button — Obsidian's default button chrome (background,
+  // shadow, padding box) needs `!important` to actually go away here, since
+  // a plain reset without it gets overridden by the theme's own button
+  // styling. Same reasoning applies to every other "flat" control below
+  // (nav/label/action buttons, day/month/year cells): a `<button>` is used
+  // for accessibility and click handling, not for its default appearance.
+  &__calendar-btn {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+    color: var(--text-muted);
+    cursor: pointer;
+
+    &:hover {
+      color: var(--text-normal);
+    }
+  }
+
+  &__panel {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    z-index: var(--layer-popover, 70);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+    width: 248px;
+    padding: 0.75em;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m);
+    background: var(--background-primary);
+    box-shadow: var(--shadow-s);
+
+    &.is-flipped {
+      left: auto;
+      right: 0;
+    }
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__nav-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    border-radius: var(--radius-s) !important;
+    padding: 0.3em !important;
+    color: var(--text-muted);
+    cursor: pointer;
+
+    &:hover {
+      background: var(--background-modifier-hover) !important;
+      color: var(--text-normal);
+    }
+  }
+
+  &__label-btn {
+    flex: 1;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    padding: 0.2em !important;
+    border-radius: var(--radius-s) !important;
+    font-weight: 600;
+    font-size: 0.95em;
+    text-align: center;
+    cursor: pointer;
+
+    &:hover:not(.is-static) {
+      background: var(--background-modifier-hover) !important;
+    }
+
+    &.is-static {
+      cursor: default;
+    }
+  }
+
+  &__weekdays {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    text-align: center;
+    font-size: 0.7em;
+    color: var(--text-muted);
+  }
+
+  &__grid {
+    display: grid;
+    gap: 2px;
+
+    &--days {
+      grid-template-columns: repeat(7, 1fr);
+    }
+
+    &--months,
+    &--years {
+      grid-template-columns: repeat(3, 1fr);
+      gap: 4px;
+    }
+  }
+
+  &__day,
+  &__cell {
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    padding: 0.4em 0 !important;
+    border-radius: var(--radius-s) !important;
+    font-size: 0.8em;
+    text-align: center;
+    cursor: pointer;
+
+    &:hover {
+      background: var(--background-modifier-hover) !important;
+    }
+
+    &.is-outside {
+      color: var(--text-faint);
+    }
+
+    &.is-today {
+      color: var(--text-accent);
+      font-weight: 600;
+    }
+
+    &.is-current {
+      color: var(--text-accent);
+      font-weight: 600;
+    }
+
+    &.is-selected {
+      background: var(--interactive-accent) !important;
+      color: var(--text-on-accent);
+      font-weight: 600;
+    }
+  }
+
+  &__cell {
+    padding: 0.6em 0 !important;
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: space-between;
+    border-top: 1px solid var(--background-modifier-border);
+    padding-top: 0.5em;
+  }
+
+  &__action {
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    padding: 0.2em 0.4em !important;
+    border-radius: var(--radius-s) !important;
+    font-size: 0.8em;
+    color: var(--text-muted);
+    cursor: pointer;
+
+    &:hover {
+      background: var(--background-modifier-hover) !important;
+      color: var(--text-normal);
+    }
+  }
+}

--- a/src/styles/heatmap-export.scss
+++ b/src/styles/heatmap-export.scss
@@ -19,10 +19,6 @@
     }
   }
 
-  &__date-input {
-    width: 120px;
-  }
-
   &__presets {
     display: flex;
     gap: 0.3em;
@@ -69,6 +65,10 @@
     color: var(--text-muted);
     font-size: 0.9em;
     margin-bottom: 0.75em;
+
+    &--italic {
+      font-style: italic;
+    }
   }
 
   &__footnote {
@@ -89,13 +89,50 @@
     display: flex;
     align-items: center;
     gap: 0.5em;
+    border-radius: var(--radius-s);
+    // Reserved (transparent) so lighting up border-top-color below doesn't
+    // shift layout - a highlighted box around the whole row left it
+    // ambiguous whether the drop would land above or below it; a line
+    // is unambiguous, since a drop always lands immediately before
+    // whichever row it's shown on.
+    border-top: 3px solid transparent;
+    transition: opacity 0.15s ease, border-top-color 0.15s ease;
 
     &.is-dragging {
       opacity: 0.4;
     }
 
+    &.is-drag-over {
+      border-top-color: var(--interactive-accent);
+    }
+
+    // Dim everything except the color swatch when excluded from the
+    // summary — the swatch needs to stay at full color so the user can
+    // still tell what it represents even while it's hidden elsewhere.
     &.is-excluded {
-      opacity: 0.55;
+      .heatmap-legend-modal__handle,
+      .heatmap-legend-modal__color-text,
+      .heatmap-legend-modal__label-input,
+      .heatmap-legend-modal__value-input,
+      .heatmap-legend-modal__weight-input,
+      .heatmap-legend-modal__include-toggle {
+        opacity: 0.55;
+        transition: opacity 0.15s ease;
+      }
+    }
+
+    // Hidden entirely (from both the legend and the summary) - a heavier dim
+    // than is-excluded's "summary-only" hide, same swatch exemption.
+    &.is-hidden {
+      .heatmap-legend-modal__handle,
+      .heatmap-legend-modal__color-text,
+      .heatmap-legend-modal__label-input,
+      .heatmap-legend-modal__value-input,
+      .heatmap-legend-modal__weight-input,
+      .heatmap-legend-modal__include-toggle {
+        opacity: 0.3;
+        transition: opacity 0.15s ease;
+      }
     }
   }
 
@@ -123,14 +160,31 @@
     border: 1px solid var(--background-modifier-border);
   }
 
-  &__color-input {
+  &__color-text {
     width: 100px;
+    flex-shrink: 0;
+    color: var(--text-muted);
+    font-size: 0.9em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 
-    &:disabled {
-      color: var(--text-faint);
-      cursor: default;
-      opacity: 0.7;
-    }
+  &__gradient-strip {
+    display: flex;
+    gap: 2px;
+    flex-shrink: 0;
+  }
+
+  &__gradient-strip-swatch {
+    width: 14px;
+    height: 20px;
+    border-radius: 3px;
+    border: 1px solid var(--background-modifier-border);
+  }
+
+  &__gear-button {
+    flex-shrink: 0;
   }
 
   &__label-input {
@@ -142,7 +196,8 @@
     flex-shrink: 0;
   }
 
-  &__remove-button {
+  &__weight-input {
+    width: 56px;
     flex-shrink: 0;
   }
 
@@ -153,7 +208,13 @@
 
   &__button-row {
     display: flex;
+    align-items: center;
     gap: 0.5em;
     margin-bottom: 0.75em;
+    flex-wrap: wrap;
+  }
+
+  &__mode-select {
+    flex-shrink: 0;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,12 +31,27 @@ export interface LegendEntry {
   /** Whether this category's count appears in the summary line. Default: true. */
   includeInSummary?: boolean;
   /**
+   * Whether this category appears in the legend at all (its swatch+label
+   * line in separate mode, or its own independent line in gradient mode).
+   * Default: true. Setting this to `false` implies `includeInSummary: false`
+   * too — there's no sensible "counted but not shown anywhere" state.
+   */
+  includeInLegend?: boolean;
+  /**
    * Fixed value every day matching this color contributes, replacing the
    * day's own raw value. For categories like "Leave" whose underlying entry
    * still carries a non-zero placeholder intensity (needed just to keep the
    * day colored/logged), this forces the real reported value (e.g. 0 hours).
    */
   valueOverride?: number;
+  /**
+   * Multiplies this color's day count when it's combined into the gradient
+   * mode's shared total (see `buildSummaryModel`'s "gradient" legendMode) —
+   * e.g. 0.5 for a lighter "half day" color so its days count as half a day
+   * toward the shared count instead of a full one. Default: 1. Has no effect
+   * in separate-rows mode, where each color already shows its own raw count.
+   */
+  countWeight?: number;
 }
 
 /** Remembered Export-tab preferences, persisted across sessions. */
@@ -53,6 +68,15 @@ export interface ExportDefaults {
   skipWeekends?: boolean;
   valueLabel?: string;
   legend?: LegendEntry[];
+  /**
+   * "separate" (default): one legend/summary line per intensity color.
+   * "gradient": all non-blank intensity colors combine into a single
+   * GitHub-style swatch strip with one shared label and one combined count;
+   * the blank/background color always stays its own separate line either way.
+   */
+  legendMode?: "separate" | "gradient";
+  /** Shared label shown next to the gradient swatch strip when legendMode is "gradient". */
+  gradientLabel?: string;
   exportFolder?: string;
   /** Omits the day-count/day-type breakdown line entirely. */
   hideSummary?: boolean;

--- a/src/utils/report/__tests__/heatmapHtml.spec.ts
+++ b/src/utils/report/__tests__/heatmapHtml.spec.ts
@@ -53,7 +53,7 @@ describe("countWeeksInRange", () => {
 });
 
 describe("countBandsInRange", () => {
-  it("fits a 12-month range in 2 bands for columns (max 10 months/band)", () => {
+  it("fits a 12-month range in 2 bands for columns (max 8 months/band)", () => {
     expect(countBandsInRange("2025-01-01", "2025-12-31", 1, "columns", true)).toBe(2);
   });
 
@@ -301,7 +301,7 @@ describe("buildHeatmapGridHtml", () => {
     });
 
     it("uses a smaller per-band month cap for rows than columns", () => {
-      // Same 7-month range: fits in 1 band for columns (cap 10), needs 2 for rows (cap 6).
+      // Same 7-month range: fits in 1 band for columns (cap 8), needs 2 for rows (cap 6).
       const columnsHtml = buildHeatmapGridHtml({
         entriesByDate: {},
         colorsList,
@@ -365,8 +365,8 @@ describe("buildHeatmapGridHtml", () => {
     });
 
     it("does not cap columns mode's band count the same way", () => {
-      // Same 42-month range: columns has no band-count cap, only a
-      // 10-months-per-band cap, so it should use 5 bands (ceil(42/10)), not 4.
+      // Same 42-month range: columns has no band-count cap, only an
+      // 8-months-per-band cap, so it should use 6 bands (ceil(42/8)), not 4.
       const html = buildHeatmapGridHtml({
         entriesByDate: {},
         colorsList,
@@ -379,8 +379,8 @@ describe("buildHeatmapGridHtml", () => {
       });
 
       const bands = splitBands(html);
-      expect(bands).toHaveLength(5);
-      bands.forEach((band) => expect(countMonthLabels(band)).toBeLessThanOrEqual(10));
+      expect(bands).toHaveLength(6);
+      bands.forEach((band) => expect(countMonthLabels(band)).toBeLessThanOrEqual(8));
     });
   });
 
@@ -436,6 +436,53 @@ describe("buildHeatmapGridHtml", () => {
       });
 
       expect(html).toMatch(/grid-column:1;grid-row:\d+ \/ span \d+;[^"]*writing-mode:vertical-rl[^"]*">2025</);
+    });
+
+    it("renders the rows-mode month label horizontally, centered across its whole span (unlike the rotated year column)", () => {
+      // Mirrors columns mode centering its own month header horizontally
+      // across the week-columns it spans (LABEL_STYLE) - here on the other
+      // axis. Still spans the whole multi-row run and centers within it,
+      // same as the year column - just not rotated, since a month name is
+      // short enough to read normally there.
+      const html = buildHeatmapGridHtml({
+        entriesByDate: {},
+        colorsList,
+        startDate: "2025-12-01",
+        endDate: "2026-02-28",
+        weekStartDay: 1,
+        orientation: "rows",
+        splitByMonth: true,
+        showMonthLabels: true,
+      });
+
+      const decMatch = html.match(/<div style="grid-column:2;grid-row:\d+ \/ span \d+;([^"]*)">Dec<\/div>/);
+      expect(decMatch).not.toBeNull();
+      const [, style] = decMatch as RegExpMatchArray;
+      expect(style).not.toContain("writing-mode");
+      expect(style).toContain("justify-content:center");
+    });
+
+    it("gives the rows-mode year and month leading columns breathing room from their neighbors", () => {
+      // With weekends shown and week-start-date on too, the year, month, and
+      // week-start-date columns sit right next to each other with only the
+      // grid's 2px gap between them, which read as touching/overlapping.
+      const html = buildHeatmapGridHtml({
+        entriesByDate: {},
+        colorsList,
+        startDate: "2025-12-01",
+        endDate: "2026-02-28",
+        weekStartDay: 1,
+        orientation: "rows",
+        splitByMonth: true,
+        showMonthLabels: true,
+        showWeekStartDate: true,
+        skipWeekends: false,
+      });
+
+      // Year column (col 1) spans its whole multi-row run.
+      expect(html).toMatch(/grid-column:1;grid-row:\d+ \/ span \d+;[^"]*margin-right:4px[^"]*">2025</);
+      // Month column (col 2) does too.
+      expect(html).toMatch(/grid-column:2;grid-row:\d+ \/ span \d+;[^"]*margin-right:4px[^"]*">Dec</);
     });
 
     it("keeps the columns-mode year row horizontal (not rotated)", () => {

--- a/src/utils/report/__tests__/legend.spec.ts
+++ b/src/utils/report/__tests__/legend.spec.ts
@@ -1,9 +1,23 @@
 import { ReportDay, ReportModel } from "../reportModel";
-import { buildLegendHtml, buildSummaryModel, computeDayTypeCounts, LegendEntry } from "../legend";
+import {
+  DayTypeCount,
+  buildGradientLegendHtml,
+  buildLegendHtml,
+  buildSummaryModel,
+  computeDayTypeCounts,
+  getLegendVisibility,
+  nextLegendVisibility,
+  setLegendVisibility,
+  LegendEntry,
+} from "../legend";
 import { EMPTY_CELL_COLOR } from "../heatmapHtml";
 
 function day(overrides: Partial<ReportDay> & { date: string }): ReportDay {
   return { weekday: 1, ...overrides };
+}
+
+function countFor(counts: DayTypeCount[], color: string): number | undefined {
+  return counts.find((c) => c.entry.color === color)?.count;
 }
 
 describe("computeDayTypeCounts", () => {
@@ -21,15 +35,44 @@ describe("computeDayTypeCounts", () => {
 
     const { counts, otherCount } = computeDayTypeCounts(days, legend);
 
-    expect(counts).toEqual({ Workday: 2, Leave: 1 });
+    expect(countFor(counts, "#196127")).toBe(2);
+    expect(countFor(counts, "#8b949e")).toBe(1);
     expect(otherCount).toBe(0);
+  });
+
+  it("returns one {entry, count} pair per input entry, in input order", () => {
+    const { counts } = computeDayTypeCounts([], legend);
+
+    expect(counts).toHaveLength(2);
+    expect(counts[0].entry).toBe(legend[0]);
+    expect(counts[1].entry).toBe(legend[1]);
+  });
+
+  it("keeps separate counts for entries that share the same (blank) label", () => {
+    // Auto-populated, not-yet-customized entries all start with a blank
+    // label — counting by label instead of by color/entry would collide
+    // these into a single bucket instead of tracking each color separately.
+    const unlabeledLegend: LegendEntry[] = [
+      { color: "#196127", label: "" },
+      { color: "#8b949e", label: "" },
+    ];
+    const days = [
+      day({ date: "2026-07-13", color: "#196127" }),
+      day({ date: "2026-07-14", color: "#196127" }),
+      day({ date: "2026-07-15", color: "#8b949e" }),
+    ];
+
+    const { counts } = computeDayTypeCounts(days, unlabeledLegend);
+
+    expect(countFor(counts, "#196127")).toBe(2);
+    expect(countFor(counts, "#8b949e")).toBe(1);
   });
 
   it("matches case-insensitively and ignores surrounding whitespace", () => {
     const days = [day({ date: "2026-07-13", color: " #196127 ".trim().toUpperCase() })];
     const { counts, otherCount } = computeDayTypeCounts(days, legend);
 
-    expect(counts.Workday).toBe(1);
+    expect(countFor(counts, "#196127")).toBe(1);
     expect(otherCount).toBe(0);
   });
 
@@ -41,7 +84,8 @@ describe("computeDayTypeCounts", () => {
 
     const { counts, otherCount } = computeDayTypeCounts(days, legend);
 
-    expect(counts).toEqual({ Workday: 0, Leave: 0 });
+    expect(countFor(counts, "#196127")).toBe(0);
+    expect(countFor(counts, "#8b949e")).toBe(0);
     expect(otherCount).toBe(2);
   });
 
@@ -49,7 +93,7 @@ describe("computeDayTypeCounts", () => {
     const days = [day({ date: "2026-07-13", color: "#196127" })];
     const { counts, otherCount } = computeDayTypeCounts(days, []);
 
-    expect(counts).toEqual({});
+    expect(counts).toEqual([]);
     expect(otherCount).toBe(1);
   });
 
@@ -62,8 +106,8 @@ describe("computeDayTypeCounts", () => {
 
     const { counts } = computeDayTypeCounts(days, legendWithBlank, 5);
 
-    expect(counts.Workday).toBe(1);
-    expect(counts["Rest day"]).toBe(4);
+    expect(countFor(counts, "#196127")).toBe(1);
+    expect(countFor(counts, EMPTY_CELL_COLOR)).toBe(4);
   });
 
   it("does not add a blank count when totalDaysInRange is omitted", () => {
@@ -72,7 +116,7 @@ describe("computeDayTypeCounts", () => {
 
     const { counts } = computeDayTypeCounts(days, legendWithBlank);
 
-    expect(counts["Rest day"]).toBe(0);
+    expect(countFor(counts, EMPTY_CELL_COLOR)).toBe(0);
   });
 });
 
@@ -87,6 +131,193 @@ describe("buildLegendHtml", () => {
     expect(html).toContain("background-color:#196127");
     expect(html).toContain("&lt;b&gt;Workday&lt;/b&gt;");
     expect(html).not.toContain("<b>Workday</b>");
+  });
+
+  it("skips an entry with no label instead of rendering a blank swatch", () => {
+    const html = buildLegendHtml([
+      { color: "#196127", label: "Workday" },
+      { color: "#8b949e", label: "", includeInSummary: false },
+    ]);
+
+    expect(html).toContain("background-color:#196127");
+    expect(html).not.toContain("background-color:#8b949e");
+  });
+
+  it("returns an empty string when every entry is unlabeled", () => {
+    expect(buildLegendHtml([{ color: "#8b949e", label: "", includeInSummary: false }])).toBe("");
+  });
+
+  it("skips an entry hidden entirely (includeInLegend: false), even with a label", () => {
+    const html = buildLegendHtml([
+      { color: "#196127", label: "Workday" },
+      { color: "#8b949e", label: "Leave", includeInLegend: false },
+    ]);
+
+    expect(html).toContain("background-color:#196127");
+    expect(html).not.toContain("background-color:#8b949e");
+    expect(html).not.toContain(">Leave<");
+  });
+});
+
+describe("legend visibility state machine", () => {
+  it("defaults to shown for a plain entry", () => {
+    expect(getLegendVisibility({ color: "#196127", label: "Workday" })).toBe("shown");
+  });
+
+  it("reads summaryHidden from includeInSummary: false alone", () => {
+    expect(getLegendVisibility({ color: "#196127", label: "Workday", includeInSummary: false })).toBe(
+      "summaryHidden",
+    );
+  });
+
+  it("reads hidden from includeInLegend: false, regardless of includeInSummary", () => {
+    expect(
+      getLegendVisibility({ color: "#196127", label: "Workday", includeInLegend: false, includeInSummary: false }),
+    ).toBe("hidden");
+  });
+
+  it("cycles shown -> summaryHidden -> hidden -> shown", () => {
+    expect(nextLegendVisibility("shown")).toBe("summaryHidden");
+    expect(nextLegendVisibility("summaryHidden")).toBe("hidden");
+    expect(nextLegendVisibility("hidden")).toBe("shown");
+  });
+
+  it("setLegendVisibility('hidden') implies includeInSummary: false too", () => {
+    const entry: LegendEntry = { color: "#196127", label: "Workday" };
+    setLegendVisibility(entry, "hidden");
+
+    expect(entry.includeInLegend).toBe(false);
+    expect(entry.includeInSummary).toBe(false);
+  });
+
+  it("setLegendVisibility('shown') clears both flags back to the default", () => {
+    const entry: LegendEntry = {
+      color: "#196127",
+      label: "Workday",
+      includeInLegend: false,
+      includeInSummary: false,
+    };
+    setLegendVisibility(entry, "shown");
+
+    expect(getLegendVisibility(entry)).toBe("shown");
+  });
+
+  it("setLegendVisibility('summaryHidden') clears includeInLegend even if previously hidden", () => {
+    const entry: LegendEntry = {
+      color: "#196127",
+      label: "Workday",
+      includeInLegend: false,
+      includeInSummary: false,
+    };
+    setLegendVisibility(entry, "summaryHidden");
+
+    expect(getLegendVisibility(entry)).toBe("summaryHidden");
+    expect(entry.includeInLegend).toBeUndefined();
+  });
+});
+
+describe("buildGradientLegendHtml", () => {
+  const colors = ["#c6e48b", "#7bc96f", "#239a3b", "#196127"];
+
+  it("returns an empty string for an empty palette and no independent entries", () => {
+    expect(buildGradientLegendHtml([], "Activity")).toBe("");
+  });
+
+  it("renders one swatch per palette color, in the given order", () => {
+    const html = buildGradientLegendHtml(colors, "Activity");
+    colors.forEach((color) => expect(html).toContain(`background-color:${color}`));
+    expect(html.indexOf(colors[0])).toBeLessThan(html.indexOf(colors[1]));
+    expect(html.indexOf(colors[2])).toBeLessThan(html.indexOf(colors[3]));
+  });
+
+  it("shows the shared label beside the strip, with no Less/More caption", () => {
+    const html = buildGradientLegendHtml(colors, "Activity");
+    expect(html).toContain(">Activity<");
+    // No font size small enough reliably fits both words under as few as
+    // two swatches without truncating or overlapping - dropped entirely.
+    expect(html).not.toContain("Less");
+    expect(html).not.toContain("More");
+  });
+
+  it("escapes the shared label and omits it entirely when blank", () => {
+    const escaped = buildGradientLegendHtml(colors, "<b>Activity</b>");
+    expect(escaped).toContain("&lt;b&gt;Activity&lt;/b&gt;");
+    expect(escaped).not.toContain("<b>Activity</b>");
+
+    const blank = buildGradientLegendHtml(colors, "   ");
+    expect(blank).not.toContain("<span style=\"font-size:0.85em;\">");
+  });
+
+  it("never includes the blank/background color in the strip, even if passed in", () => {
+    const html = buildGradientLegendHtml([...colors, EMPTY_CELL_COLOR], "Activity");
+    expect(html).not.toContain(`background-color:${EMPTY_CELL_COLOR}`);
+  });
+
+  it("renders independent (non-palette) entries as their own swatch+label items in the same row as the strip", () => {
+    const html = buildGradientLegendHtml(colors, "Activity", [
+      { color: "#8b95a5", label: "Leave" },
+      { color: "#f59e0b", label: "Rest day work" },
+    ]);
+
+    expect(html).toContain("background-color:#8b95a5");
+    expect(html).toContain(">Leave<");
+    expect(html).toContain("background-color:#f59e0b");
+    expect(html).toContain(">Rest day work<");
+    // Exactly one wrapping row (one top-level flex container), not a
+    // separate line below the gradient strip.
+    expect(html.match(/flex-wrap:wrap;gap:12px;margin:8px 0 16px;align-items:center;/g)?.length).toBe(1);
+  });
+
+  it("omits an independent entry with no label", () => {
+    const html = buildGradientLegendHtml(colors, "Activity", [{ color: "#8b95a5", label: "" }]);
+    expect(html).not.toContain("#8b95a5");
+  });
+
+  it("omits an independent entry hidden entirely (includeInLegend: false)", () => {
+    const html = buildGradientLegendHtml(colors, "Activity", [
+      { color: "#8b95a5", label: "Leave", includeInLegend: false },
+    ]);
+    expect(html).not.toContain("#8b95a5");
+    expect(html).not.toContain(">Leave<");
+  });
+
+  it("still renders independent entries even when the palette itself is empty", () => {
+    const html = buildGradientLegendHtml([], "Activity", [{ color: "#8b95a5", label: "Leave" }]);
+    expect(html).toContain(">Leave<");
+  });
+
+  it("places the combined gradient item at the same position its palette colors occupy in the full legend array, not hardcoded first", () => {
+    const legend: LegendEntry[] = [
+      { color: "#8b95a5", label: "Leave" },
+      { color: "#c6e48b", label: "" },
+      { color: "#7bc96f", label: "" },
+    ];
+    const html = buildGradientLegendHtml(["#c6e48b", "#7bc96f"], "Activity", legend);
+
+    // "Leave" comes first in the array, so it renders before the gradient
+    // item too - dragging the gradient group row (see LegendModal) must be
+    // able to actually change this order, not just cosmetically in the editor.
+    expect(html.indexOf(">Leave<")).toBeLessThan(html.indexOf(">Activity<"));
+  });
+
+  it("omits the whole gradient item (strip + label) when every palette-color entry is hidden entirely", () => {
+    const legend: LegendEntry[] = [
+      { color: "#c6e48b", label: "", includeInLegend: false },
+      { color: "#7bc96f", label: "", includeInLegend: false },
+    ];
+    const html = buildGradientLegendHtml(["#c6e48b", "#7bc96f"], "Activity", legend);
+
+    expect(html).toBe("");
+  });
+
+  it("keeps showing the gradient item when only some palette colors are hidden", () => {
+    const legend: LegendEntry[] = [
+      { color: "#c6e48b", label: "", includeInLegend: false },
+      { color: "#7bc96f", label: "" },
+    ];
+    const html = buildGradientLegendHtml(["#c6e48b", "#7bc96f"], "Activity", legend);
+
+    expect(html).toContain(">Activity<");
   });
 });
 
@@ -183,6 +414,20 @@ describe("buildSummaryModel", () => {
     ]);
   });
 
+  it("still matches a blank-labeled, summary-excluded entry's color instead of counting it as Other", () => {
+    // LegendModal keeps a blank-labeled row only when it's excluded from the
+    // summary (the only way to hide a color from both the legend and the
+    // summary line) — its days must still land on its own color, not "Other".
+    const legend: LegendEntry[] = [
+      { color: "#196127", label: "Workday" },
+      { color: "#8b949e", label: "", includeInSummary: false },
+    ];
+
+    expect(buildSummaryModel(model, { valueLabel: "hours", legend }).dayTypeParts).toEqual([
+      { label: "Workday", value: 2 },
+    ]);
+  });
+
   it("returns an empty dayTypeParts array (not a blank placeholder) when every legend entry is excluded", () => {
     const legend: LegendEntry[] = [
       { color: "#196127", label: "Workday", includeInSummary: false },
@@ -223,6 +468,218 @@ describe("buildSummaryModel", () => {
     expect(buildSummaryModel(model, { hideSummary: true, hideAllValues: true })).toEqual({
       dayTypeParts: [],
       total: null,
+    });
+  });
+
+  describe("legendMode: gradient", () => {
+    const colorsList = ["#196127", "#8b949e"];
+
+    it("combines all palette-color entries into one part labeled with the shared gradientLabel", () => {
+      const legend: LegendEntry[] = [
+        { color: "#196127", label: "" },
+        { color: "#8b949e", label: "" },
+      ];
+
+      expect(
+        buildSummaryModel(model, { legend, legendMode: "gradient", gradientLabel: "Activity", colorsList }).dayTypeParts,
+      ).toEqual([{ label: "Activity", value: 3 }]);
+    });
+
+    it("keeps a matched color that isn't in colorsList as its own independent part, not folded into the gradient", () => {
+      // "#8b949e" is used in the data and matched by the legend, but isn't
+      // part of the configured palette (e.g. a one-off custom color) - it
+      // must stay its own line, exactly like the blank color does.
+      const legend: LegendEntry[] = [
+        { color: "#196127", label: "" },
+        { color: "#8b949e", label: "Custom" },
+      ];
+
+      expect(
+        buildSummaryModel(model, {
+          legend,
+          legendMode: "gradient",
+          gradientLabel: "Activity",
+          colorsList: ["#196127"],
+        }).dayTypeParts,
+      ).toEqual([
+        { label: "Activity", value: 2 },
+        { label: "Custom", value: 1 },
+      ]);
+    });
+
+    it("scales a color's contribution by its countWeight (e.g. a lighter 'half day' color)", () => {
+      const legend: LegendEntry[] = [
+        { color: "#196127", label: "" }, // 2 days, default weight 1
+        { color: "#8b949e", label: "", countWeight: 0.5 }, // 1 day, half weight
+      ];
+
+      expect(
+        buildSummaryModel(model, { legend, legendMode: "gradient", gradientLabel: "Workday", colorsList }).dayTypeParts,
+      ).toEqual([{ label: "Workday", value: 2.5 }]);
+    });
+
+    it("never applies a weight to the blank entry, even if one were set", () => {
+      const sparseModel: ReportModel = {
+        startDate: "2026-07-13",
+        endDate: "2026-07-17",
+        weeks: [
+          {
+            weekStart: "2026-07-13",
+            days: [day({ date: "2026-07-13", color: "#196127", value: 8 })],
+          },
+        ],
+        summary: { totalDays: 1, totalValue: 8, activeWeeks: 1 },
+      };
+      const legend: LegendEntry[] = [
+        { color: "#196127", label: "" },
+        // 4 gap days; a weight here (if it were honored) would misleadingly
+        // shrink/grow the blank line - it must always show the raw count.
+        { color: EMPTY_CELL_COLOR, label: "Rest day", countWeight: 0.5 },
+      ];
+
+      expect(
+        buildSummaryModel(sparseModel, {
+          legend,
+          legendMode: "gradient",
+          gradientLabel: "Workday",
+          colorsList: ["#196127"],
+        }).dayTypeParts,
+      ).toEqual([
+        { label: "Workday", value: 1 },
+        { label: "Rest day", value: 4 },
+      ]);
+    });
+
+    it("rounds away floating-point drift from repeated fractional weights", () => {
+      const threeDayModel: ReportModel = {
+        startDate: "2026-07-13",
+        endDate: "2026-07-15",
+        weeks: [
+          {
+            weekStart: "2026-07-13",
+            days: [
+              day({ date: "2026-07-13", color: "#196127" }),
+              day({ date: "2026-07-14", color: "#196127" }),
+              day({ date: "2026-07-15", color: "#196127" }),
+            ],
+          },
+        ],
+        summary: { totalDays: 3, totalValue: 0, activeWeeks: 1 },
+      };
+      // 3 * 0.1 === 0.30000000000000004 in raw IEEE754 arithmetic.
+      const legend: LegendEntry[] = [{ color: "#196127", label: "", countWeight: 0.1 }];
+
+      expect(
+        buildSummaryModel(threeDayModel, {
+          legend,
+          legendMode: "gradient",
+          gradientLabel: "Workday",
+          colorsList: ["#196127"],
+        }).dayTypeParts[0].value,
+      ).toBe(0.3);
+    });
+
+    it("keeps the blank entry as its own separate part, never folded into the gradient total", () => {
+      const sparseModel: ReportModel = {
+        startDate: "2026-07-13",
+        endDate: "2026-07-17", // 5 calendar days
+        weeks: [
+          {
+            weekStart: "2026-07-13",
+            days: [day({ date: "2026-07-13", color: "#196127", value: 8 })], // only 1 logged
+          },
+        ],
+        summary: { totalDays: 1, totalValue: 8, activeWeeks: 1 },
+      };
+      const legend: LegendEntry[] = [
+        { color: "#196127", label: "" },
+        { color: EMPTY_CELL_COLOR, label: "Rest day" },
+      ];
+
+      expect(
+        buildSummaryModel(sparseModel, {
+          legend,
+          legendMode: "gradient",
+          gradientLabel: "Activity",
+          colorsList: ["#196127"],
+        }).dayTypeParts,
+      ).toEqual([
+        { label: "Activity", value: 1 },
+        { label: "Rest day", value: 4 },
+      ]);
+    });
+
+    it("excludes a specific color from the gradient total when its includeInSummary is false", () => {
+      const legend: LegendEntry[] = [
+        { color: "#196127", label: "" },
+        { color: "#8b949e", label: "", includeInSummary: false },
+      ];
+
+      expect(
+        buildSummaryModel(model, { legend, legendMode: "gradient", gradientLabel: "Activity", colorsList }).dayTypeParts,
+      ).toEqual([{ label: "Activity", value: 2 }]);
+    });
+
+    it("omits the combined part entirely when gradientLabel is blank", () => {
+      const legend: LegendEntry[] = [{ color: "#196127", label: "" }];
+
+      expect(
+        buildSummaryModel(model, { legend, legendMode: "gradient", colorsList: ["#196127"] }).dayTypeParts,
+      ).toEqual([{ label: "Other", value: 1 }]);
+    });
+
+    it("still adds an Other bucket for unmatched colors in gradient mode", () => {
+      const legend: LegendEntry[] = [{ color: "#196127", label: "" }];
+
+      expect(
+        buildSummaryModel(model, {
+          legend,
+          legendMode: "gradient",
+          gradientLabel: "Activity",
+          colorsList: ["#196127"],
+        }).dayTypeParts,
+      ).toEqual([
+        { label: "Activity", value: 2 },
+        { label: "Other", value: 1 },
+      ]);
+    });
+
+    it("positions the combined part according to where the palette colors actually sit in the legend array, not hardcoded first", () => {
+      const legend: LegendEntry[] = [
+        { color: "#8b949e", label: "Leave" }, // independent, listed first
+        { color: "#196127", label: "" }, // palette, listed second
+      ];
+
+      // Dragging the gradient group row (see LegendModal) after another
+      // category must actually change this order, not just cosmetically in
+      // the editor.
+      expect(
+        buildSummaryModel(model, {
+          legend,
+          legendMode: "gradient",
+          gradientLabel: "Activity",
+          colorsList: ["#196127"],
+        }).dayTypeParts,
+      ).toEqual([
+        { label: "Leave", value: 1 },
+        { label: "Activity", value: 2 },
+      ]);
+    });
+
+    it("omits the combined line entirely (not as a zero) when every palette color is excluded from the summary", () => {
+      const legend: LegendEntry[] = [
+        { color: "#196127", label: "", includeInSummary: false },
+        { color: "#8b949e", label: "", includeInSummary: false },
+      ];
+
+      expect(
+        buildSummaryModel(model, {
+          legend,
+          legendMode: "gradient",
+          gradientLabel: "Activity",
+          colorsList: ["#196127", "#8b949e"],
+        }).dayTypeParts,
+      ).toEqual([]);
     });
   });
 });

--- a/src/utils/report/__tests__/reportHtml.spec.ts
+++ b/src/utils/report/__tests__/reportHtml.spec.ts
@@ -1,5 +1,6 @@
 import { ReportModel } from "../reportModel";
 import { buildReportHtml } from "../reportHtml";
+import { EMPTY_CELL_COLOR } from "../heatmapHtml";
 
 const model: ReportModel = {
   startDate: "2026-07-13",
@@ -217,5 +218,79 @@ describe("buildReportHtml", () => {
     // regardless (it's just unused); check no actual span is rendered.
     expect(html).not.toContain('<span class="wlr-day__value">');
     expect(html).toContain("<h3>Mon, Jul 13, 2026</h3>");
+  });
+
+  describe("legendMode: gradient", () => {
+    it("combines the non-blank legend entry into the gradient swatch strip with a shared count", () => {
+      const html = buildReportHtml(model, {
+        title: "Work Log Report",
+        generatedAt: "2026-07-17",
+        heatmapHtml: "",
+        legend: [{ color: "#7bc96f", label: "" }],
+        legendMode: "gradient",
+        gradientLabel: "Activity",
+        colorsList: ["#7bc96f"],
+      });
+
+      expect(html).toContain("background-color:#7bc96f");
+      const summaryText = (html.match(/<div class="wlr-summary">(.*?)<\/div>/g) ?? []).join(" ");
+      expect(summaryText).toContain("Activity: 1");
+      expect(summaryText).toContain("Other: 1");
+    });
+
+    it("still renders the blank entry as its own separate swatch and summary line", () => {
+      const html = buildReportHtml(model, {
+        title: "Work Log Report",
+        generatedAt: "2026-07-17",
+        heatmapHtml: "",
+        legend: [
+          { color: "#7bc96f", label: "" },
+          { color: EMPTY_CELL_COLOR, label: "Rest day" },
+        ],
+        legendMode: "gradient",
+        gradientLabel: "Activity",
+        colorsList: ["#7bc96f"],
+      });
+
+      expect(html).toContain(">Rest day<");
+      // This fixture's 2-day range is fully logged (no gap days), so the
+      // blank count is 0 - the point here is that it renders as its own
+      // line at all, separately from the gradient's combined count.
+      const summaryText = (html.match(/<div class="wlr-summary">(.*?)<\/div>/g) ?? []).join(" ");
+      expect(summaryText).toContain("Rest day: 0");
+    });
+
+    it("does not render individual per-color swatch rows for non-blank entries", () => {
+      const html = buildReportHtml(model, {
+        title: "Work Log Report",
+        generatedAt: "2026-07-17",
+        heatmapHtml: "",
+        legend: [{ color: "#7bc96f", label: "Workday" }],
+        legendMode: "gradient",
+        gradientLabel: "Activity",
+        colorsList: ["#7bc96f"],
+      });
+
+      // "Workday" is the per-entry label, unused for display in gradient mode.
+      expect(html).not.toContain(">Workday<");
+    });
+
+    it("still renders a matched color outside the palette as its own legend swatch, alongside the gradient strip", () => {
+      const html = buildReportHtml(model, {
+        title: "Work Log Report",
+        generatedAt: "2026-07-17",
+        heatmapHtml: "",
+        legend: [
+          { color: "#7bc96f", label: "" },
+          { color: "#f59e0b", label: "Rest day work" },
+        ],
+        legendMode: "gradient",
+        gradientLabel: "Activity",
+        colorsList: ["#7bc96f"],
+      });
+
+      expect(html).toContain(">Rest day work<");
+      expect(html).toContain("background-color:#f59e0b");
+    });
   });
 });

--- a/src/utils/report/__tests__/reportMarkdown.spec.ts
+++ b/src/utils/report/__tests__/reportMarkdown.spec.ts
@@ -1,5 +1,6 @@
 import { ReportModel } from "../reportModel";
 import { buildReportMarkdown } from "../reportMarkdown";
+import { EMPTY_CELL_COLOR } from "../heatmapHtml";
 
 const model: ReportModel = {
   startDate: "2026-07-13",
@@ -212,5 +213,76 @@ describe("buildReportMarkdown", () => {
     const metaIndex = lines.findIndex((line) => line.includes("Report generated"));
     expect(lines[metaIndex + 1]).toBe("");
     expect(lines[metaIndex + 2]).toBe("MARKER");
+  });
+
+  describe("legendMode: gradient", () => {
+    it("combines the non-blank entry into the gradient swatch strip with a shared count", () => {
+      const markdown = buildReportMarkdown(model, {
+        title: "Work Log Report",
+        generatedAt: "2026-07-17",
+        heatmapHtml: "",
+        legend: [{ color: "#7bc96f", label: "" }],
+        legendMode: "gradient",
+        gradientLabel: "Activity",
+        colorsList: ["#7bc96f"],
+      });
+
+      expect(markdown).toContain("background-color:#7bc96f");
+      const lines = markdown.split("\n");
+      expect(lines).toContain("Activity: 1 · Other: 1<br>Total value: 8");
+    });
+
+    it("still renders the blank entry as its own separate swatch and summary line", () => {
+      const markdown = buildReportMarkdown(model, {
+        title: "Work Log Report",
+        generatedAt: "2026-07-17",
+        heatmapHtml: "",
+        legend: [
+          { color: "#7bc96f", label: "" },
+          { color: EMPTY_CELL_COLOR, label: "Rest day" },
+        ],
+        legendMode: "gradient",
+        gradientLabel: "Activity",
+        colorsList: ["#7bc96f"],
+      });
+
+      expect(markdown).toContain(">Rest day<");
+      const lines = markdown.split("\n");
+      // Jul 14 has no color at all, so it's genuinely unmatched -> Other: 1,
+      // on top of the gradient's own combined count and blank's separate one.
+      expect(lines).toContain("Activity: 1 · Rest day: 0 · Other: 1<br>Total value: 8");
+    });
+
+    it("does not render individual per-color swatch rows for non-blank entries", () => {
+      const markdown = buildReportMarkdown(model, {
+        title: "Work Log Report",
+        generatedAt: "2026-07-17",
+        heatmapHtml: "",
+        legend: [{ color: "#7bc96f", label: "Workday" }],
+        legendMode: "gradient",
+        gradientLabel: "Activity",
+        colorsList: ["#7bc96f"],
+      });
+
+      expect(markdown).not.toContain(">Workday<");
+    });
+
+    it("still renders a matched color outside the palette as its own legend swatch, alongside the gradient strip", () => {
+      const markdown = buildReportMarkdown(model, {
+        title: "Work Log Report",
+        generatedAt: "2026-07-17",
+        heatmapHtml: "",
+        legend: [
+          { color: "#7bc96f", label: "" },
+          { color: "#f59e0b", label: "Rest day work" },
+        ],
+        legendMode: "gradient",
+        gradientLabel: "Activity",
+        colorsList: ["#7bc96f"],
+      });
+
+      expect(markdown).toContain(">Rest day work<");
+      expect(markdown).toContain("background-color:#f59e0b");
+    });
   });
 });

--- a/src/utils/report/heatmapHtml.ts
+++ b/src/utils/report/heatmapHtml.ts
@@ -37,7 +37,7 @@ export const MAX_WEEKS_PER_BAND = 53;
  * export would otherwise grow uncomfortably wide, so it gets a smaller cap
  * — see `MAX_BANDS_ROWS` below for the other half of that constraint.
  */
-export const MAX_MONTHS_PER_BAND_COLUMNS = 10;
+export const MAX_MONTHS_PER_BAND_COLUMNS = 8;
 export const MAX_MONTHS_PER_BAND_ROWS = 6;
 
 /**
@@ -104,13 +104,32 @@ const LABEL_STYLE =
 const LEADING_LABEL_STYLE =
   "font-size:10px;color:var(--text-muted,#6b7280);white-space:nowrap;display:flex;align-items:center;justify-content:flex-end;text-align:right;margin-right:4px;justify-self:end;";
 
-// The year column in rows mode spans many week-rows but sits in its own
-// leading column alongside every other band's — with horizontal text, a
-// 4-digit year would force that column (and so every band) noticeably
-// wider. Rotating it vertical keeps the column about as narrow as a single
-// character, which matters here since rows-mode bands stack side by side.
+// The year column in rows mode spans many week-rows (potentially a whole
+// band's worth) but sits in its own leading column, one per band stacked
+// side by side. A 4-digit year rendered as ordinary horizontal, centered
+// text (LABEL_STYLE) would force the column (and so every band) noticeably
+// wider. Rotating the text vertical keeps the column about as narrow as a
+// single character, with the label becoming a full-height strip running the
+// whole span instead of one wide line of text. `margin-right` gives it
+// breathing room from whichever column is next. The month column
+// (SPANNING_LABEL_STYLE below) has the same multi-row span and centering,
+// just without the rotation - a year run can cover many months, too long to
+// stay narrow if written normally, while a month name is short enough not
+// to need it.
 const VERTICAL_LABEL_STYLE =
-  "font-size:10px;color:var(--text-muted,#6b7280);white-space:nowrap;display:flex;align-items:center;justify-content:center;writing-mode:vertical-rl;text-orientation:mixed;";
+  "font-size:10px;color:var(--text-muted,#6b7280);white-space:nowrap;display:flex;align-items:center;justify-content:center;writing-mode:vertical-rl;text-orientation:mixed;margin-right:4px;";
+
+// The month column in rows mode, like the year column above, spans many
+// week-rows in its own leading column - but a month name is short enough to
+// read normally (horizontal) instead of needing to be rotated. Centered
+// (align-items:center) across the whole span, exactly mirroring how columns
+// mode centers its own month header horizontally across the week-columns it
+// spans (LABEL_STYLE) - here just the other axis. Sits in an `auto`-sized
+// column like LEADING_LABEL_STYLE (so no `min-width:0` guard), but centered
+// rather than right-aligned, since there's no adjacent fixed-size track it
+// needs to read flush against the way the week-start-date column does.
+const SPANNING_LABEL_STYLE =
+  "font-size:10px;color:var(--text-muted,#6b7280);white-space:nowrap;display:flex;align-items:center;justify-content:center;margin-right:4px;";
 
 interface DaySlot {
   date: Date;
@@ -509,7 +528,7 @@ export function buildHeatmapGridHtml({
       monthRuns.forEach((run) => {
         const rowStart = 2 + run.start;
         items.push(
-          `<div style="grid-column:${monthCol};grid-row:${rowStart} / span ${run.span};${LABEL_STYLE}">${
+          `<div style="grid-column:${monthCol};grid-row:${rowStart} / span ${run.span};${SPANNING_LABEL_STYLE}">${
             run.label ? escapeHtml(run.label) : ""
           }</div>`,
         );

--- a/src/utils/report/legend.ts
+++ b/src/utils/report/legend.ts
@@ -6,53 +6,119 @@ import { LegendEntry } from "src/types";
 
 export type { LegendEntry } from "src/types";
 
+export interface DayTypeCount {
+  entry: LegendEntry;
+  count: number;
+}
+
 /**
  * Matches each day's already-resolved color against the legend (case-
  * insensitive, trimmed). Days with no color, or a color not in the legend,
  * fall into `otherCount`. Blank days (no entry at all — never present in
  * `days`) are counted against whichever legend entry uses `EMPTY_CELL_COLOR`,
  * when `totalDaysInRange` is given.
+ *
+ * Counted by color internally (not by label) and returned as one
+ * `{entry, count}` pair per input entry, in input order — legend entries are
+ * frequently auto-populated with a blank label before the user customizes
+ * them (see `LegendModal`), so multiple entries sharing the same (blank)
+ * label must not collide into a single counted bucket the way keying by
+ * label would cause.
  */
 export function computeDayTypeCounts(
   days: ReportDay[],
   legend: LegendEntry[],
   totalDaysInRange?: number,
-): { counts: Record<string, number>; otherCount: number } {
-  const counts: Record<string, number> = {};
+): { counts: DayTypeCount[]; otherCount: number } {
+  const countByColor = new Map<string, number>();
   legend.forEach((entry) => {
-    counts[entry.label] = 0;
+    countByColor.set(normalizeColor(entry.color), 0);
   });
-
-  const byColor = new Map(legend.map((entry) => [normalizeColor(entry.color), entry.label]));
 
   let otherCount = 0;
   days.forEach((day) => {
-    const label = day.color ? byColor.get(normalizeColor(day.color)) : undefined;
-    if (label !== undefined) {
-      counts[label] += 1;
+    const normalized = day.color ? normalizeColor(day.color) : undefined;
+    if (normalized !== undefined && countByColor.has(normalized)) {
+      countByColor.set(normalized, (countByColor.get(normalized) ?? 0) + 1);
     } else {
       otherCount += 1;
     }
   });
 
-  const blankLabel = byColor.get(normalizeColor(EMPTY_CELL_COLOR));
-  if (blankLabel !== undefined && totalDaysInRange !== undefined) {
-    counts[blankLabel] += Math.max(0, totalDaysInRange - days.length);
+  if (totalDaysInRange !== undefined) {
+    const blankNormalized = normalizeColor(EMPTY_CELL_COLOR);
+    if (countByColor.has(blankNormalized)) {
+      countByColor.set(
+        blankNormalized,
+        (countByColor.get(blankNormalized) ?? 0) + Math.max(0, totalDaysInRange - days.length),
+      );
+    }
   }
 
+  const counts: DayTypeCount[] = legend.map((entry) => ({
+    entry,
+    count: countByColor.get(normalizeColor(entry.color)) ?? 0,
+  }));
+
   return { counts, otherCount };
+}
+
+/**
+ * A category's three-state legend/summary visibility, cycled by the eye
+ * button in `LegendModal` (unrelated to whether its color is a true
+ * intensity-palette color, which is a separate "does it belong to the
+ * gradient" concern — see `LegendModal.paletteEntriesInOrder`):
+ * - "shown": appears in both the legend and the summary count (default).
+ * - "summaryHidden": still appears in the legend, but its count is omitted
+ *   from the summary line.
+ * - "hidden": omitted from both entirely.
+ * There's deliberately no fourth "counted but not shown" state — that
+ * wouldn't make sense to a reader of the exported report.
+ */
+export type LegendVisibility = "shown" | "summaryHidden" | "hidden";
+
+export function getLegendVisibility(entry: LegendEntry): LegendVisibility {
+  if (entry.includeInLegend === false) return "hidden";
+  if (entry.includeInSummary === false) return "summaryHidden";
+  return "shown";
+}
+
+/** Mutates `entry` so `getLegendVisibility(entry) === visibility` afterwards. */
+export function setLegendVisibility(entry: LegendEntry, visibility: LegendVisibility): void {
+  if (visibility === "shown") {
+    entry.includeInSummary = undefined;
+    entry.includeInLegend = undefined;
+  } else if (visibility === "summaryHidden") {
+    entry.includeInSummary = false;
+    entry.includeInLegend = undefined;
+  } else {
+    entry.includeInSummary = false;
+    entry.includeInLegend = false;
+  }
+}
+
+/** shown -> summaryHidden -> hidden -> shown -> ... */
+export function nextLegendVisibility(visibility: LegendVisibility): LegendVisibility {
+  if (visibility === "shown") return "summaryHidden";
+  if (visibility === "summaryHidden") return "hidden";
+  return "shown";
 }
 
 /**
  * Renders the legend as a small swatch+label list, for embedding under the
  * heatmap. Fully inline-styled (no `<style>` block / class-based CSS) for
  * the same reason as the grid itself — robust against Obsidian's own theme
- * CSS when embedded raw in a Markdown note.
+ * CSS when embedded raw in a Markdown note. Entries left without a label
+ * (kept in `legend` only so their color still matches/counts correctly — see
+ * `LegendModal`) are skipped here, since there'd be nothing to show next to
+ * the swatch — as is any entry explicitly hidden from the legend entirely
+ * (`getLegendVisibility(entry) === "hidden"`).
  */
 export function buildLegendHtml(legend: LegendEntry[]): string {
-  if (legend.length === 0) return "";
+  const labeled = legend.filter((entry) => entry.label.trim() !== "" && entry.includeInLegend !== false);
+  if (labeled.length === 0) return "";
 
-  const items = legend
+  const items = labeled
     .map(
       (entry) =>
         `<div style="display:flex;align-items:center;gap:4px;">` +
@@ -66,6 +132,97 @@ export function buildLegendHtml(legend: LegendEntry[]): string {
   return `<div style="display:flex;flex-wrap:wrap;gap:12px;margin:8px 0 16px;">${items}</div>`;
 }
 
+/**
+ * Renders the gradient-mode legend: a GitHub-contribution-graph-style swatch
+ * strip covering every configured intensity color, low-to-high (including
+ * ones not currently used in this range), with the shared label beside it,
+ * vertically centered against the strip. (Earlier versions also tried
+ * captioning the strip with "Less"/"More" underneath, but there was no font
+ * size small enough to fit both words under as few as two swatches without
+ * either truncating or overlapping - dropped rather than keep chasing a size
+ * that doesn't reliably exist.) The swatches themselves always render in
+ * `colorsList`'s own given order (the palette's true low-to-high intensity
+ * order) regardless of `legend`'s order - that part is never reordered.
+ *
+ * `legend` is the FULL legend array (not pre-filtered) so this can place the
+ * combined gradient item at the same position its palette colors actually
+ * occupy there, exactly mirroring `LegendModal.renderGradientGroupRow`'s own
+ * squashing - dragging the gradient group row before/after another category
+ * now actually changes the exported legend's order too, not just the
+ * editor's own display. Every matched color that ISN'T a true intensity-
+ * palette color (the blank/background color, or a custom color used on
+ * individual days outside the palette) renders as its own swatch+label item
+ * at its own position, in the same flex row as the gradient strip. The whole
+ * gradient item (strip + label) is omitted entirely when every palette-color
+ * entry has been explicitly hidden (`includeInLegend: false` on all of
+ * them - see the gradient group row's own eye button, which always applies
+ * to every palette color at once); with no legend info at all for the
+ * palette colors, it defaults to shown, like any other color would.
+ */
+export function buildGradientLegendHtml(
+  colorsList: string[],
+  gradientLabel: string,
+  legend: LegendEntry[] = [],
+): string {
+  const SWATCH_SIZE = 10;
+  const SWATCH_GAP = 2;
+
+  const blankNormalized = normalizeColor(EMPTY_CELL_COLOR);
+  const intensityColors = colorsList.filter((color) => normalizeColor(color) !== blankNormalized);
+  const paletteColors = new Set(intensityColors.map(normalizeColor));
+
+  const paletteEntries = legend.filter((entry) => paletteColors.has(normalizeColor(entry.color)));
+  const gradientHidden =
+    paletteEntries.length > 0 && paletteEntries.every((entry) => entry.includeInLegend === false);
+
+  let gradientItem = "";
+  if (intensityColors.length > 0 && !gradientHidden) {
+    const swatches = intensityColors
+      .map(
+        (color) =>
+          `<span style="display:inline-block;width:${SWATCH_SIZE}px;height:${SWATCH_SIZE}px;border-radius:2px;background-color:${escapeHtml(
+            color,
+          )};"></span>`,
+      )
+      .join("");
+    const label = gradientLabel.trim();
+
+    gradientItem =
+      `<div style="display:flex;align-items:center;gap:8px;">` +
+      `<div style="display:flex;gap:${SWATCH_GAP}px;">${swatches}</div>` +
+      (label ? `<span style="font-size:0.85em;">${escapeHtml(label)}</span>` : "") +
+      `</div>`;
+  }
+
+  const items: string[] = [];
+  let gradientInserted = false;
+  legend.forEach((entry) => {
+    if (paletteColors.has(normalizeColor(entry.color))) {
+      if (!gradientInserted && gradientItem) {
+        items.push(gradientItem);
+        gradientInserted = true;
+      }
+      return;
+    }
+    if (entry.label.trim() === "" || entry.includeInLegend === false) return;
+    items.push(
+      `<div style="display:flex;align-items:center;gap:4px;">` +
+        `<span style="display:inline-block;width:${SWATCH_SIZE}px;height:${SWATCH_SIZE}px;border-radius:2px;background-color:${escapeHtml(
+          entry.color,
+        )};"></span>` +
+        `<span style="font-size:0.85em;">${escapeHtml(entry.label)}</span></div>`,
+    );
+  });
+  // No palette-color entries turned up in `legend` at all (e.g. an empty
+  // legend, or the caller genuinely just wants the strip) - append rather
+  // than lose it entirely.
+  if (!gradientInserted && gradientItem) items.push(gradientItem);
+
+  if (items.length === 0) return "";
+
+  return `<div style="display:flex;flex-wrap:wrap;gap:12px;margin:8px 0 16px;align-items:center;">${items.join("")}</div>`;
+}
+
 export interface SummaryPart {
   label: string;
   value: number;
@@ -74,6 +231,19 @@ export interface SummaryPart {
 export interface SummaryOptions {
   valueLabel?: string;
   legend?: LegendEntry[];
+  /**
+   * "separate" (default): one summary part per non-blank legend entry.
+   * "gradient": every entry whose color is actually in `colorsList` (the
+   * configured intensity palette) is combined into one part labeled
+   * `gradientLabel`; any other matched color — the blank/background color,
+   * or a custom color used on individual days outside the palette — stays
+   * its own independent part either way.
+   */
+  legendMode?: "separate" | "gradient";
+  /** Shared label for the combined gradient part, when legendMode is "gradient". */
+  gradientLabel?: string;
+  /** The configured intensity palette — determines which colors count toward the gradient's combined total when legendMode is "gradient". */
+  colorsList?: string[];
   /** Omits the day-count/day-type breakdown entirely (both the legend breakdown and the no-legend "Days logged" fallback). */
   hideSummary?: boolean;
   /** Omits the "Total <value label>" part. */
@@ -92,18 +262,29 @@ export interface SummaryModel {
 /**
  * Builds the report's summary as a day-type breakdown plus a total, shared by
  * the Markdown and HTML serializers so the breakdown logic isn't duplicated.
- * With a legend: one part per legend entry with `includeInSummary !== false`
- * (+ "Other" for unmatched days — always shown when non-zero, regardless of
- * which specific entries are hidden). Without a legend: falls back to a flat
- * "Days logged" count. Hidden entries' days still count correctly toward
- * matching/`otherCount` — they're just not displayed as their own line.
- * `dayTypeParts` is empty (not a blank placeholder line) whenever there's
- * nothing to show — every legend entry excluded, or `hideSummary` set — so
- * callers can omit the line entirely instead of rendering it blank.
+ * With a legend: one part per non-blank legend entry with
+ * `includeInSummary !== false` in "separate" mode, or in "gradient" mode,
+ * one combined part for every entry whose color is actually in
+ * `colorsList` (the true intensity palette) — any other matched color (the
+ * blank/background color, or a custom color used on individual days outside
+ * the palette) always stays its own independent part instead, in both
+ * modes (+ "Other" for unmatched days — always shown when non-zero,
+ * regardless of which specific entries are hidden). In gradient mode, each
+ * palette entry's day count is scaled by its own `countWeight` (default 1)
+ * before being summed — e.g. a lighter "half day" color set to 0.5
+ * contributes half a day per match instead of a full one; independent
+ * parts are never weighted. Without a legend: falls back to a flat "Days
+ * logged" count. Hidden entries' days still count correctly toward
+ * matching/`otherCount`/the gradient total — they're just not displayed as
+ * their own line. `dayTypeParts` is empty (not a blank placeholder line)
+ * whenever there's nothing to show — every legend entry excluded, or
+ * `hideSummary` set — so callers can omit the line entirely instead of
+ * rendering it blank.
  */
 export function buildSummaryModel(model: ReportModel, options: SummaryOptions = {}): SummaryModel {
   const valueLabel = options.valueLabel?.trim() || "value";
   const legend = options.legend ?? [];
+  const legendMode = options.legendMode ?? "separate";
 
   const dayTypeParts: SummaryPart[] = [];
 
@@ -117,10 +298,59 @@ export function buildSummaryModel(model: ReportModel, options: SummaryOptions = 
         ) + 1;
       const { counts, otherCount } = computeDayTypeCounts(allDays, legend, totalDaysInRange);
 
-      legend.forEach((entry) => {
-        if (entry.includeInSummary === false) return;
-        dayTypeParts.push({ label: entry.label, value: counts[entry.label] ?? 0 });
-      });
+      if (legendMode === "gradient") {
+        const paletteColors = new Set((options.colorsList ?? []).map(normalizeColor));
+        const gradientLabel = options.gradientLabel?.trim();
+
+        let gradientTotal = 0;
+        let anyPaletteIncluded = false;
+        // Where the combined part gets spliced in, once totalling is done -
+        // the position of the first palette-color entry actually encountered
+        // in `counts` (which follows the legend's own array order), so
+        // dragging the gradient group row before/after other categories (see
+        // `LegendModal.renderGradientGroupRow`) actually changes where the
+        // combined line lands, instead of it always being hardcoded first.
+        let gradientPosition = -1;
+        const parts: SummaryPart[] = [];
+
+        counts.forEach(({ entry, count }) => {
+          const isPaletteColor = paletteColors.has(normalizeColor(entry.color));
+          if (isPaletteColor) {
+            if (gradientPosition === -1) gradientPosition = parts.length;
+            if (entry.includeInSummary === false) return;
+            anyPaletteIncluded = true;
+            gradientTotal += count * (entry.countWeight ?? 1);
+          } else {
+            if (entry.includeInSummary === false) return;
+            if (entry.label.trim() === "") return;
+            // Not a true intensity-palette color — the blank/background
+            // color, or a custom color used on individual days outside the
+            // palette — stays its own independent line instead of folding
+            // into the combined total.
+            parts.push({ label: entry.label, value: count });
+          }
+        });
+        // Guards against float noise from non-power-of-2 weights (e.g. 0.3),
+        // not against any real precision need — a handful of summed terms.
+        gradientTotal = Math.round(gradientTotal * 100) / 100;
+
+        // Omitted entirely (not shown as "0") when nothing actually
+        // contributes - e.g. every palette color has been toggled to
+        // summary-hidden/fully-hidden via the gradient group row's eye
+        // button - mirroring how an individual excluded entry drops its
+        // whole line in separate mode, rather than showing a zero.
+        if (gradientLabel && anyPaletteIncluded) {
+          const insertAt = gradientPosition === -1 ? parts.length : gradientPosition;
+          parts.splice(insertAt, 0, { label: gradientLabel, value: gradientTotal });
+        }
+        dayTypeParts.push(...parts);
+      } else {
+        counts.forEach(({ entry, count }) => {
+          if (entry.includeInSummary === false) return;
+          if (entry.label.trim() === "") return;
+          dayTypeParts.push({ label: entry.label, value: count });
+        });
+      }
       if (otherCount > 0) {
         dayTypeParts.push({ label: "Other", value: otherCount });
       }

--- a/src/utils/report/reportHtml.ts
+++ b/src/utils/report/reportHtml.ts
@@ -1,7 +1,7 @@
 import { ReportDay, ReportModel } from "src/utils/report/reportModel";
 import { escapeHtml } from "src/utils/report/heatmapHtml";
 import { formatDayLabel, formatWeekLabel } from "src/utils/report/dateLabels";
-import { LegendEntry, buildLegendHtml, buildSummaryModel } from "src/utils/report/legend";
+import { LegendEntry, buildGradientLegendHtml, buildLegendHtml, buildSummaryModel } from "src/utils/report/legend";
 
 export interface ReportHtmlOptions {
   title: string;
@@ -12,6 +12,12 @@ export interface ReportHtmlOptions {
   valueLabel?: string;
   /** Drives both the embedded legend and the summary's day-type breakdown. */
   legend?: LegendEntry[];
+  /** "separate" (default) or "gradient" — see buildSummaryModel/buildGradientLegendHtml. */
+  legendMode?: "separate" | "gradient";
+  /** Shared label for the gradient's combined swatch strip, when legendMode is "gradient". */
+  gradientLabel?: string;
+  /** Full intensity color palette, low→high — renders the gradient strip regardless of which colors are actually used in this range. */
+  colorsList?: string[];
   /** Omits the day-count/day-type breakdown line entirely. */
   hideSummary?: boolean;
   /** Omits the "Total <value label>" line. */
@@ -75,6 +81,9 @@ export function buildReportHtml(
     heatmapHtml,
     valueLabel,
     legend = [],
+    legendMode = "separate",
+    gradientLabel = "",
+    colorsList = [],
     hideSummary,
     hideTotalValue,
     hideAllValues = false,
@@ -83,6 +92,9 @@ export function buildReportHtml(
   const { dayTypeParts, total } = buildSummaryModel(model, {
     valueLabel,
     legend,
+    legendMode,
+    gradientLabel,
+    colorsList,
     hideSummary,
     hideTotalValue,
     hideAllValues,
@@ -90,7 +102,8 @@ export function buildReportHtml(
   const dayTypeLine = dayTypeParts.map((p) => `${escapeHtml(p.label)}: ${p.value}`).join(" · ");
   const totalLine = total ? `${escapeHtml(total.label)}: ${total.value}` : "";
   const summaryLine = dayTypeLine && totalLine ? `${dayTypeLine}<br>${totalLine}` : dayTypeLine || totalLine;
-  const legendHtml = buildLegendHtml(legend);
+  const legendHtml =
+    legendMode === "gradient" ? buildGradientLegendHtml(colorsList, gradientLabel, legend) : buildLegendHtml(legend);
 
   const weeksHtml = model.weeks
     .map(

--- a/src/utils/report/reportMarkdown.ts
+++ b/src/utils/report/reportMarkdown.ts
@@ -1,6 +1,6 @@
 import { ReportModel } from "src/utils/report/reportModel";
 import { formatDayLabel, formatWeekLabel } from "src/utils/report/dateLabels";
-import { LegendEntry, buildLegendHtml, buildSummaryModel } from "src/utils/report/legend";
+import { LegendEntry, buildGradientLegendHtml, buildLegendHtml, buildSummaryModel } from "src/utils/report/legend";
 
 export interface ReportMarkdownOptions {
   title: string;
@@ -11,6 +11,12 @@ export interface ReportMarkdownOptions {
   valueLabel?: string;
   /** Drives both the embedded legend and the summary's day-type breakdown. */
   legend?: LegendEntry[];
+  /** "separate" (default) or "gradient" — see buildSummaryModel/buildGradientLegendHtml. */
+  legendMode?: "separate" | "gradient";
+  /** Shared label for the gradient's combined swatch strip, when legendMode is "gradient". */
+  gradientLabel?: string;
+  /** Full intensity color palette, low→high — renders the gradient strip regardless of which colors are actually used in this range. */
+  colorsList?: string[];
   /** Omits the day-count/day-type breakdown line entirely. */
   hideSummary?: boolean;
   /** Omits the "Total <value label>" line. */
@@ -32,6 +38,9 @@ export function buildReportMarkdown(
     heatmapHtml,
     valueLabel,
     legend = [],
+    legendMode = "separate",
+    gradientLabel = "",
+    colorsList = [],
     hideSummary,
     hideTotalValue,
     hideAllValues,
@@ -51,6 +60,9 @@ export function buildReportMarkdown(
   const { dayTypeParts, total } = buildSummaryModel(model, {
     valueLabel,
     legend,
+    legendMode,
+    gradientLabel,
+    colorsList,
     hideSummary,
     hideTotalValue,
     hideAllValues,
@@ -64,7 +76,8 @@ export function buildReportMarkdown(
   }
   lines.push(heatmapHtml);
   lines.push("");
-  const legendHtml = buildLegendHtml(legend);
+  const legendHtml =
+    legendMode === "gradient" ? buildGradientLegendHtml(colorsList, gradientLabel, legend) : buildLegendHtml(legend);
   if (legendHtml) {
     lines.push(legendHtml);
     lines.push("");

--- a/src/views/ExportView/ExportView.tsx
+++ b/src/views/ExportView/ExportView.tsx
@@ -4,7 +4,7 @@ import { ColorsList, Entry } from "src/types";
 import { useHeatmapContext } from "src/context/heatmap/heatmap.context";
 import { useAppContext } from "src/context/app/app.context";
 import { fillEntriesWithIntensityByDate } from "src/utils/intensity";
-import { formatDateToISO8601, getFirstDayOfYear, getLastDayOfYear, getToday } from "src/utils/date";
+import { formatDateToISO8601, getFirstDayOfYear, getLastDayOfYear, getToday, parseUTCDate } from "src/utils/date";
 import { openFileInLeaf } from "src/utils/heatmapBox";
 import { formatGeneratedAt } from "src/utils/report/dateLabels";
 import { readNoteBodies } from "src/utils/report/noteBody";
@@ -18,8 +18,10 @@ import {
 import { buildReportHtml } from "src/utils/report/reportHtml";
 import { buildReportMarkdown } from "src/utils/report/reportMarkdown";
 import { notify } from "src/utils/notify";
-import { LegendModal } from "src/modals/LegendModal";
+import { LegendModal, LegendDisplayMode } from "src/modals/LegendModal";
 import { LegendEntry } from "src/utils/report/legend";
+import { normalizeColor } from "src/utils/report/legendMatch";
+import { DatePicker } from "src/components/DatePicker/DatePicker";
 
 const PREVIEW_DEBOUNCE_MS = 300;
 const SETTINGS_SAVE_DEBOUNCE_MS = 500;
@@ -65,27 +67,75 @@ function defaultRange(
 }
 
 /**
- * Colors actually in use within the current range, palette-intensity colors
- * first (in their natural low→high order), then any other custom colors, then
- * the blank/no-entry color last — so the legend editor can be pre-populated
- * with real swatches instead of asking the user to know/type hex codes.
+ * Every color the calendar can ever show — every configured intensity color
+ * (in their natural low→high order), then any other custom colors actually
+ * used in the current range but outside that palette, then the blank/
+ * no-entry color last. There's no manual "Add row" anymore (see
+ * `LegendModal`), so this is the complete, automatic source of truth for
+ * what the legend editor offers.
+ *
+ * A color not currently used in this range defaults to excluded from the
+ * summary/gradient total (and so, per `buildSummaryModel`/`buildLegendHtml`,
+ * hidden from the rendered legend/summary too) until the user explicitly
+ * turns it back on — otherwise a freshly auto-populated legend would
+ * immediately clutter the export with zero-count categories that have never
+ * actually happened yet. The blank color follows the same rule based on
+ * whether the range has any gap (unlogged) days at all.
  */
-function getDetectedColors(model: ReportModel | null, colorsList: ColorsList): string[] {
-  const used = new Set<string>();
-  model?.weeks.forEach((week) => week.days.forEach((day) => {
-    if (day.color) used.add(day.color);
-  }));
+export function buildDefaultLegendEntries(model: ReportModel | null, colorsList: ColorsList): LegendEntry[] {
+  const usedColors = new Set<string>();
+  let loggedDayCount = 0;
+  model?.weeks.forEach((week) =>
+    week.days.forEach((day) => {
+      loggedDayCount += 1;
+      if (day.color) usedColors.add(day.color);
+    }),
+  );
 
-  const ordered: string[] = [];
-  colorsList.forEach((color) => {
-    if (used.has(color)) {
-      ordered.push(color);
-      used.delete(color);
-    }
+  const extraCustomColors = [...usedColors].filter((color) => !colorsList.includes(color));
+  const totalDaysInRange = model
+    ? Math.round(
+        (parseUTCDate(model.endDate).getTime() - parseUTCDate(model.startDate).getTime()) /
+          (1000 * 60 * 60 * 24),
+      ) + 1
+    : 0;
+  const hasBlankDays = totalDaysInRange > loggedDayCount;
+
+  return [...colorsList, ...extraCustomColors, EMPTY_CELL_COLOR].map((color) => {
+    const isBlank = normalizeColor(color) === normalizeColor(EMPTY_CELL_COLOR);
+    const isUsed = isBlank ? hasBlankDays : usedColors.has(color);
+    return { color, label: "", includeInSummary: isUsed ? undefined : false };
   });
-  ordered.push(...used);
-  ordered.push(EMPTY_CELL_COLOR);
-  return ordered;
+}
+
+/**
+ * The "Refresh" merge target — every color used ANYWHERE in `entriesByDate`
+ * (already unfiltered by the export's own start/end date pickers - see
+ * `ExportView`'s own `entriesByDate`, built straight from `allFilteredEntries`),
+ * not just within whichever narrower range is currently selected. Without
+ * this, refreshing while viewing a short range would treat a color that's
+ * only used outside that range as "gone", dropping its label/weight/
+ * visibility customizations instead of just leaving them dormant until the
+ * range includes one of its days again. `weekStartDay` doesn't affect which
+ * colors turn up, only how days would be grouped into weeks - irrelevant
+ * here, so a fixed value keeps this callable without any component state.
+ */
+export function buildRefreshBaseline(
+  entriesByDate: Record<string, Entry>,
+  colorsList: ColorsList,
+): LegendEntry[] {
+  const fullRange = computeDataRange(entriesByDate);
+  if (!fullRange) return buildDefaultLegendEntries(null, colorsList);
+
+  const fullModel = buildReportModel({
+    entriesByDate,
+    colorsList,
+    bodiesByPath: {},
+    startDate: fullRange.start,
+    endDate: fullRange.end,
+    weekStartDay: 1,
+  });
+  return buildDefaultLegendEntries(fullModel, colorsList);
 }
 
 function sanitizeFilename(name: string): string {
@@ -163,6 +213,8 @@ function ExportView() {
   const [hideAllValues, setHideAllValues] = useState(exportDefaults?.hideAllValues ?? false);
   const [valueLabel, setValueLabel] = useState(exportDefaults?.valueLabel ?? "");
   const [legend, setLegend] = useState<LegendEntry[]>(exportDefaults?.legend ?? []);
+  const [legendMode, setLegendMode] = useState<LegendDisplayMode>(exportDefaults?.legendMode ?? "separate");
+  const [gradientLabel, setGradientLabel] = useState(exportDefaults?.gradientLabel ?? "");
   const [exportFolder, setExportFolder] = useState(exportDefaults?.exportFolder ?? "");
 
   const debounceRef = useRef<number | null>(null);
@@ -199,6 +251,8 @@ function ExportView() {
           hideAllValues,
           valueLabel,
           legend,
+          legendMode,
+          gradientLabel,
           exportFolder,
         },
       });
@@ -223,6 +277,8 @@ function ExportView() {
     hideAllValues,
     valueLabel,
     legend,
+    legendMode,
+    gradientLabel,
     exportFolder,
   ]);
 
@@ -319,6 +375,9 @@ function ExportView() {
       heatmapHtml: heatmapGridHtml,
       valueLabel,
       legend,
+      legendMode,
+      gradientLabel,
+      colorsList,
       hideSummary,
       hideTotalValue,
       hideAllValues,
@@ -330,6 +389,9 @@ function ExportView() {
     heatmapGridHtml,
     valueLabel,
     legend,
+    legendMode,
+    gradientLabel,
+    colorsList,
     hideSummary,
     hideTotalValue,
     hideAllValues,
@@ -392,6 +454,9 @@ function ExportView() {
       heatmapHtml: heatmapGridHtml,
       valueLabel,
       legend,
+      legendMode,
+      gradientLabel,
+      colorsList,
       hideSummary,
       hideTotalValue,
       hideAllValues,
@@ -417,15 +482,22 @@ function ExportView() {
   }
 
   function handleEditLegend() {
-    const detected = getDetectedColors(model, colorsList);
-    const existingColors = new Set(legend.map((entry) => entry.color.trim().toLowerCase()));
-    const withDetected = [
-      ...legend,
-      ...detected
-        .filter((color) => !existingColors.has(color.trim().toLowerCase()))
-        .map((color) => ({ color, label: "" })),
-    ];
-    new LegendModal(app, withDetected, detected, setLegend).open();
+    // Whole-calendar-scoped, not just the export's currently selected date
+    // range, so every color the calendar can ever show is available to
+    // populate from/reset/refresh back to - regardless of whether any of its
+    // days happen to fall within the range selected right now.
+    const baseline = buildRefreshBaseline(entriesByDate, colorsList);
+    // Only auto-populate from the baseline on true first-time entry (nothing
+    // saved yet) - once the legend exists, reopening the editor shows
+    // exactly what was last saved, untouched. Re-syncing against the palette
+    // (new colors, dropped stale ones) only happens when the user explicitly
+    // clicks "Refresh" or "Reset" inside the modal.
+    const initialEntries = legend.length > 0 ? legend : baseline;
+    new LegendModal(app, initialEntries, baseline, colorsList, legendMode, gradientLabel, (entries, mode, label) => {
+      setLegend(entries);
+      setLegendMode(mode);
+      setGradientLabel(label);
+    }).open();
   }
 
   return (
@@ -433,21 +505,11 @@ function ExportView() {
       <div className="heatmap-export__controls">
         <label>
           {t("report.startDate")}
-          <input
-            className="heatmap-export__date-input"
-            type="date"
-            value={startDate}
-            onChange={(e) => setStartDate(e.target.value)}
-          />
+          <DatePicker value={startDate} onChange={setStartDate} weekStartDay={weekStartDay} ariaLabel={t("report.startDate")} />
         </label>
         <label>
           {t("report.endDate")}
-          <input
-            className="heatmap-export__date-input"
-            type="date"
-            value={endDate}
-            onChange={(e) => setEndDate(e.target.value)}
-          />
+          <DatePicker value={endDate} onChange={setEndDate} weekStartDay={weekStartDay} ariaLabel={t("report.endDate")} />
         </label>
         <div className="heatmap-export__presets">
           <button onClick={handlePresetAllLoggedData}>{t("report.presetAllLoggedData")}</button>
@@ -462,6 +524,7 @@ function ExportView() {
         <label>
           {t("report.orientation")}
           <select
+            className="dropdown"
             value={orientation}
             onChange={(e) => setOrientation(e.target.value as HeatmapOrientation)}
           >
@@ -471,7 +534,11 @@ function ExportView() {
         </label>
         <label>
           {t("report.weekStartDay")}
-          <select value={weekStartDay} onChange={(e) => setWeekStartDay(Number(e.target.value))}>
+          <select
+            className="dropdown"
+            value={weekStartDay}
+            onChange={(e) => setWeekStartDay(Number(e.target.value))}
+          >
             {WEEK_START_DAY_OPTIONS.map(({ value, key }) => (
               <option key={key} value={value}>
                 {t(`weekdaysLong.${key}`)}

--- a/src/views/ExportView/__tests__/ExportView.legend.spec.ts
+++ b/src/views/ExportView/__tests__/ExportView.legend.spec.ts
@@ -1,0 +1,100 @@
+import { ColorsList, Entry } from "src/types";
+import { ReportModel } from "src/utils/report/reportModel";
+import { EMPTY_CELL_COLOR } from "src/utils/report/heatmapHtml";
+import { buildDefaultLegendEntries, buildRefreshBaseline } from "../ExportView";
+
+const colorsList: ColorsList = ["#c6e48b", "#7bc96f", "#239a3b", "#196127"];
+
+function modelWithDays(startDate: string, endDate: string, dayColors: string[]): ReportModel {
+  return {
+    startDate,
+    endDate,
+    weeks: [
+      {
+        weekStart: startDate,
+        days: dayColors.map((color, i) => ({
+          date: `2026-07-${String(13 + i).padStart(2, "0")}`,
+          weekday: 1,
+          color,
+        })),
+      },
+    ],
+    summary: { totalDays: dayColors.length, totalValue: 0, activeWeeks: 1 },
+  };
+}
+
+describe("buildDefaultLegendEntries", () => {
+  it("returns one entry per palette color, in order, plus the blank color last", () => {
+    const entries = buildDefaultLegendEntries(null, colorsList);
+
+    expect(entries.map((e) => e.color)).toEqual([...colorsList, EMPTY_CELL_COLOR]);
+    expect(entries.every((e) => e.label === "")).toBe(true);
+  });
+
+  it("defaults a color actually used in the range to shown (includeInSummary undefined)", () => {
+    const model = modelWithDays("2026-07-13", "2026-07-13", ["#7bc96f"]);
+    const entries = buildDefaultLegendEntries(model, colorsList);
+
+    const used = entries.find((e) => e.color === "#7bc96f");
+    expect(used?.includeInSummary).toBeUndefined();
+  });
+
+  it("defaults a color not used in the range to hidden (includeInSummary: false)", () => {
+    const model = modelWithDays("2026-07-13", "2026-07-13", ["#7bc96f"]);
+    const entries = buildDefaultLegendEntries(model, colorsList);
+
+    const unused = entries.find((e) => e.color === "#196127");
+    expect(unused?.includeInSummary).toBe(false);
+  });
+
+  it("defaults the blank color to hidden when the range has no gap days", () => {
+    // 1 logged day, 1-day range -> no gaps.
+    const model = modelWithDays("2026-07-13", "2026-07-13", ["#7bc96f"]);
+    const entries = buildDefaultLegendEntries(model, colorsList);
+
+    expect(entries.find((e) => e.color === EMPTY_CELL_COLOR)?.includeInSummary).toBe(false);
+  });
+
+  it("defaults the blank color to shown when the range has at least one gap day", () => {
+    // 1 logged day, 3-day range -> 2 gap days.
+    const model = modelWithDays("2026-07-13", "2026-07-15", ["#7bc96f"]);
+    const entries = buildDefaultLegendEntries(model, colorsList);
+
+    expect(entries.find((e) => e.color === EMPTY_CELL_COLOR)?.includeInSummary).toBeUndefined();
+  });
+
+  it("appends a used custom color that isn't in the palette, before the blank color", () => {
+    const model = modelWithDays("2026-07-13", "2026-07-13", ["#d18616"]);
+    const entries = buildDefaultLegendEntries(model, colorsList);
+
+    const colors = entries.map((e) => e.color);
+    expect(colors).toEqual([...colorsList, "#d18616", EMPTY_CELL_COLOR]);
+    expect(entries.find((e) => e.color === "#d18616")?.includeInSummary).toBeUndefined();
+  });
+
+  it("hides everything by default when there is no model (nothing logged, no range)", () => {
+    const entries = buildDefaultLegendEntries(null, colorsList);
+    expect(entries.every((e) => e.includeInSummary === false)).toBe(true);
+  });
+});
+
+describe("buildRefreshBaseline", () => {
+  it("includes a custom color used anywhere in entriesByDate, not just within any one narrower range", () => {
+    // Far apart dates - the point is that a color from months ago still
+    // counts as "used somewhere in the whole calendar", exactly the case
+    // that a narrower export date-range picker would miss.
+    const entriesByDate: Record<string, Entry> = {
+      "2026-01-05": { date: "2026-01-05", intensity: 1 },
+      "2026-07-13": { date: "2026-07-13", customColor: "#d18616" },
+    };
+
+    const baseline = buildRefreshBaseline(entriesByDate, colorsList);
+
+    expect(baseline.map((e) => e.color)).toEqual([...colorsList, "#d18616", EMPTY_CELL_COLOR]);
+    expect(baseline.find((e) => e.color === "#d18616")?.includeInSummary).toBeUndefined();
+  });
+
+  it("falls back to the plain (all-hidden) defaults when there's no data at all", () => {
+    expect(buildRefreshBaseline({}, colorsList)).toEqual(buildDefaultLegendEntries(null, colorsList));
+  });
+});


### PR DESCRIPTION
### Changed
- Export tab: redesigned the legend editor. Intensity colors can now be combined into a single gradient row, with a gear icon for setting each color’s day-count weight and fixed value. Category visibility now uses a three-state toggle: shown everywhere, hidden from summaries, or fully hidden. Drag-to-reorder interactions are smoother and provide clearer visual feedback. Refresh and reset functions are redesigned and they now behave more intuitively.
- Export tab: redesigned the DatePicker.

### Fixed
- Export tab: month labels in the weeks-as-rows layout would no longer overlap the week start dates.