### PR TITLE
Fix: honor configured Daily Notes date format when matching entries

### DIFF
--- a/src/modals/__tests__/HeatmapModal.test.ts
+++ b/src/modals/__tests__/HeatmapModal.test.ts
@@ -309,6 +309,10 @@ jest.mock("obsidian", () => {
     ButtonComponent: MockButtonComponent,
     setIcon: jest.fn(),
     getAllTags: getAllTagsMock,
+    // dataviewEntries.ts normalizes daily-note filenames via Obsidian's
+    // re-exported moment; use the real implementation here (see
+    // heatmapBox.test.ts for the same pattern).
+    moment: jest.requireActual("moment"),
   };
 });
 

--- a/src/utils/__tests__/dataviewEntries.test.ts
+++ b/src/utils/__tests__/dataviewEntries.test.ts
@@ -1,4 +1,15 @@
-import { buildEntriesFromDataview, normalizeTag } from "../dataviewEntries";
+import {
+  buildEntriesFromDataview,
+  normalizeDailyNoteFileName,
+  normalizeTag,
+} from "../dataviewEntries";
+import { getDailyNoteSettings } from "obsidian-daily-notes-interface";
+
+// Auto-mocked: every export becomes a jest.fn(). Individual tests configure
+// `getDailyNoteSettings`'s return value where the daily-note format matters;
+// everywhere else it returns `undefined`, so the code under test falls back
+// to the `YYYY-MM-DD` default (matching pre-fix behavior for ISO filenames).
+jest.mock("obsidian-daily-notes-interface");
 
 function makePage(
   name: string,
@@ -29,6 +40,58 @@ function makeDv(pages: Record<string, unknown>[]) {
   };
 }
 
+describe("normalizeDailyNoteFileName", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("leaves an already-ISO filename unchanged when no daily note format is configured", () => {
+    expect(normalizeDailyNoteFileName("2026-08-10")).toBe("2026-08-10");
+  });
+
+  it("converts a DD-MM-YYYY daily note filename to ISO using the configured format", () => {
+    (getDailyNoteSettings as jest.Mock).mockReturnValue({
+      format: "DD-MM-YYYY",
+      folder: "",
+      template: "",
+    });
+
+    expect(normalizeDailyNoteFileName("10-08-2026")).toBe("2026-08-10");
+  });
+
+  it("converts a filename in any configured moment format to ISO", () => {
+    (getDailyNoteSettings as jest.Mock).mockReturnValue({
+      format: "YYYY/MM/DD",
+      folder: "",
+      template: "",
+    });
+
+    expect(normalizeDailyNoteFileName("2026/08/10")).toBe("2026-08-10");
+  });
+
+  it("returns the original string unchanged when it doesn't match the configured format", () => {
+    (getDailyNoteSettings as jest.Mock).mockReturnValue({
+      format: "DD-MM-YYYY",
+      folder: "",
+      template: "",
+    });
+
+    // Not a daily note (e.g. a project note living in a tracked folder) —
+    // must not be mangled into a bogus date.
+    expect(normalizeDailyNoteFileName("Project Overview")).toBe(
+      "Project Overview",
+    );
+  });
+
+  it("falls back to the ISO default when reading daily note settings throws", () => {
+    (getDailyNoteSettings as jest.Mock).mockImplementation(() => {
+      throw new Error("Daily Notes plugin not available");
+    });
+
+    expect(normalizeDailyNoteFileName("2026-08-10")).toBe("2026-08-10");
+  });
+});
+
 describe("buildEntriesFromDataview", () => {
   it("returns an empty array when no property is given", () => {
     const dv = makeDv([]);
@@ -49,6 +112,29 @@ describe("buildEntriesFromDataview", () => {
       property: "exercise",
     });
     expect(dv.pages).toHaveBeenCalledWith('"daily notes"');
+  });
+
+  it("normalizes DD-MM-YYYY daily note filenames to ISO so they show up on the heatmap", () => {
+    (getDailyNoteSettings as jest.Mock).mockReturnValue({
+      format: "DD-MM-YYYY",
+      folder: "",
+      template: "",
+    });
+
+    const dv = makeDv([makePage("10-08-2026", { exercise: 10 })]);
+
+    const entries = buildEntriesFromDataview(dv as any, {
+      property: "exercise",
+    });
+
+    expect(entries).toEqual([
+      {
+        date: "2026-08-10",
+        filePath: "folder/10-08-2026.md",
+        intensity: 10,
+        content: undefined,
+      },
+    ]);
   });
 
   it("builds one entry per matching page with a single property", () => {

--- a/src/utils/dataviewEntries.ts
+++ b/src/utils/dataviewEntries.ts
@@ -1,6 +1,15 @@
 import { DataviewApi, Literal } from "obsidian-dataview";
+import { getDailyNoteSettings } from "obsidian-daily-notes-interface";
+import { moment as obsidianMoment } from "obsidian";
+// Type-only: erased at build time, so the `moment` package stays out of the
+// bundle. Obsidian's own `moment` export is typed as `typeof Moment` off an
+// `import * as Moment` (obsidian.d.ts), which has no call signature — hence
+// borrowing the callable type from the package itself. Mirrors heatmapBox.ts.
+import type Moment from "moment";
 import { Entry, FilterCondition } from "../types";
 import { parseIntensity } from "./intensity";
+
+const moment = obsidianMoment as unknown as typeof Moment;
 
 export interface DataviewEntriesParams {
   /** Folder to search in. Falsy/undefined means the whole vault. */
@@ -11,6 +20,36 @@ export interface DataviewEntriesParams {
   tags?: string[];
   /** Additional frontmatter conditions a page must satisfy (all must match). */
   filters?: FilterCondition[];
+}
+
+/**
+ * Dataview's `page.file.name` is just the note's filename with the
+ * extension stripped — it is NOT necessarily `YYYY-MM-DD`. Daily notes can
+ * be named in whatever format the user configured in Obsidian's Daily
+ * Notes/Periodic Notes settings (e.g. `DD-MM-YYYY`), but everywhere else in
+ * this plugin (grid generation, streaks, year filtering, ...) assumes
+ * entry dates are ISO `YYYY-MM-DD`. Previously the raw filename was used
+ * as-is, so anything other than an ISO-formatted daily note silently
+ * matched nothing and every box showed "no data".
+ *
+ * This reads the vault's actual configured Daily Notes format and uses it
+ * to convert the filename to canonical `YYYY-MM-DD`. If the filename
+ * doesn't strictly match that format (e.g. it's not a daily note, or the
+ * Daily Notes plugin isn't configured), the original string is returned
+ * unchanged so already-ISO names keep working exactly as before.
+ */
+export function normalizeDailyNoteFileName(fileName: string): string {
+  try {
+    const format = getDailyNoteSettings()?.format || "YYYY-MM-DD";
+    const parsed = moment(fileName, format, true);
+    return parsed.isValid() ? parsed.format("YYYY-MM-DD") : fileName;
+  } catch {
+    // Daily Notes/Periodic Notes plugin unavailable or not configured, or
+    // `moment` itself unavailable in this environment — never let date
+    // normalization take down entry building; just use the raw filename,
+    // same as pre-fix behavior.
+    return fileName;
+  }
 }
 
 /** Obsidian/Dataview tags are always `#`-prefixed; be lenient about user input that omits it. */
@@ -102,7 +141,7 @@ export function buildEntriesFromDataview(
     );
 
     entries.push({
-      date: page.file.name,
+      date: normalizeDailyNoteFileName(page.file.name),
       filePath: page.file.path,
       intensity,
       content: createContent?.(page),


### PR DESCRIPTION
Frontmatter-based entries (the heatmap-tracker codeblock / Insert Heatmap Tracker command) used Dataview's page.file.name directly as the entry date, assuming it was already ISO YYYY-MM-DD. Daily notes named in any other format (e.g. DD-MM-YYYY) never matched a box, so the heatmap showed 'no data' for every day.

normalizeDailyNoteFileName() now reads the vault's actual configured Daily Notes/Periodic Notes date format via obsidian-daily-notes-interface and converts the filename to canonical YYYY-MM-DD before it becomes an Entry. Filenames that don't match the configured format (non-daily-note pages) are left untouched, and any failure (plugin not configured, etc.) falls back to the original filename, matching prior behavior.

Fixes the reported bug: 'DD-MM-YYYY daily notes show no data on the heatmap; switching to YYYY-MM-DD makes it appear.'

Note: this covers the built-in heatmap-tracker codeblock path. The Advanced Usage dataviewjs example in the README builds entries manually and would need the same normalization applied by hand if used with a non-ISO daily note format.

## What does this change?

<!-- One or two sentences. Link the issue it closes, if any. -->

Closes #

## How was it verified?

<!-- What did you actually run or click? "Tested in my vault with a monthly
layout heatmap" is more useful than "works". -->

## Checklist

CI runs all of these on the PR — running them locally first just makes the loop
faster.

- [ ] `npm test` passes
- [ ] `npm run type-check` passes
- [ ] `npm run lint` reports no errors
- [ ] `npm run format` was run (or your editor applied Prettier)
- [ ] `CHANGELOG.md` has an entry under `## [Unreleased]`, if this is
      user-visible
- [ ] New behaviour is covered by a test, or there is a note below saying why
      not
